### PR TITLE
Use BzrBranchFormat8 in development-subtree.

### DIFF
--- a/breezy/bzr/__init__.py
+++ b/breezy/bzr/__init__.py
@@ -291,7 +291,7 @@ register_metadir(controldir.format_registry, 'development-subtree',
         'this format can only be read by bzr.dev. Please read '
         'http://doc.bazaar.canonical.com/latest/developers/development-repo.html '
         'before use.',
-    branch_format='breezy.bzr.branch.BzrBranchFormat7',
+    branch_format='breezy.bzr.branch.BzrBranchFormat8',
     tree_format='breezy.bzr.workingtree_4.WorkingTreeFormat6',
     experimental=True,
     hidden=True,

--- a/breezy/tests/blackbox/test_reference.py
+++ b/breezy/tests/blackbox/test_reference.py
@@ -27,9 +27,7 @@ from breezy.tests import TestCaseWithTransport
 class TestReference(TestCaseWithTransport):
 
     def get_default_format(self):
-        format = controldir.format_registry.make_controldir('1.9')
-        format.set_branch_format(_mod_bzrbranch.BzrBranchFormat8())
-        return format
+        return controldir.format_registry.make_controldir('development-subtree')
 
     def test_no_args_lists(self):
         branch = self.make_branch('branch')


### PR DESCRIPTION
Use BzrBranchFormat8 in development-subtree.
