### PR TITLE
Remove file ids from many of the public Tree functions.

### DIFF
--- a/breezy/annotate.py
+++ b/breezy/annotate.py
@@ -54,7 +54,7 @@ from .revision import (
 
 
 def annotate_file_tree(tree, path, to_file, verbose=False, full=False,
-    show_ids=False, branch=None, file_id=None):
+    show_ids=False, branch=None):
     """Annotate file_id in a tree.
 
     The tree should already be read_locked() when annotate_file_tree is called.
@@ -66,7 +66,6 @@ def annotate_file_tree(tree, path, to_file, verbose=False, full=False,
         reasonable text width.
     :param full: XXXX Not sure what this does.
     :param show_ids: Show revision ids in the annotation output.
-    :param file_id: The file_id to annotate (must match file path)
     :param branch: Branch to use for revision revno lookups
     """
     if branch is None:
@@ -76,7 +75,7 @@ def annotate_file_tree(tree, path, to_file, verbose=False, full=False,
 
     encoding = osutils.get_terminal_encoding()
     # Handle the show_ids case
-    annotations = list(tree.annotate_iter(path, file_id))
+    annotations = list(tree.annotate_iter(path))
     if show_ids:
         return _show_id_annotations(annotations, to_file, full, encoding)
 

--- a/breezy/archive/tar.py
+++ b/breezy/archive/tar.py
@@ -51,10 +51,10 @@ def prepare_tarball_item(tree, root, final_path, tree_path, entry, force_mtime=N
     if force_mtime is not None:
         item.mtime = force_mtime
     else:
-        item.mtime = tree.get_file_mtime(tree_path, file_id)
+        item.mtime = tree.get_file_mtime(tree_path)
     if entry.kind == "file":
         item.type = tarfile.REGTYPE
-        if tree.is_executable(tree_path, file_id):
+        if tree.is_executable(tree_path):
             item.mode = 0o755
         else:
             item.mode = 0o644
@@ -62,7 +62,7 @@ def prepare_tarball_item(tree, root, final_path, tree_path, entry, force_mtime=N
         # the tarfile contract, which wants the size of the file up front.  We
         # want to make sure it doesn't change, and we need to read it in one
         # go for content filtering.
-        content = tree.get_file_text(tree_path, file_id)
+        content = tree.get_file_text(tree_path)
         item.size = len(content)
         fileobj = BytesIO(content)
     elif entry.kind in ("directory", "tree-reference"):
@@ -75,7 +75,7 @@ def prepare_tarball_item(tree, root, final_path, tree_path, entry, force_mtime=N
         item.type = tarfile.SYMTYPE
         item.size = 0
         item.mode = 0o755
-        item.linkname = tree.get_symlink_target(tree_path, file_id)
+        item.linkname = tree.get_symlink_target(tree_path)
         fileobj = None
     else:
         raise errors.BzrError("don't know how to export {%s} of kind %r"
@@ -124,7 +124,7 @@ def tgz_generator(tree, dest, root, subdir, force_mtime=None):
             rev = tree.repository.get_revision(tree.get_revision_id())
             root_mtime = rev.timestamp
         elif tree.is_versioned(u''):
-            root_mtime = tree.get_file_mtime('', tree.get_root_id())
+            root_mtime = tree.get_file_mtime('')
         else:
             root_mtime = None
 

--- a/breezy/archive/zip.py
+++ b/breezy/archive/zip.py
@@ -56,15 +56,14 @@ def zip_archive_generator(tree, dest, root, subdir=None,
         with closing(zipfile.ZipFile(buf, "w", compression)) as zipf, \
              tree.lock_read():
             for dp, tp, ie in _export_iter_entries(tree, subdir):
-                file_id = getattr(ie, 'file_id', None)
-                mutter("  export {%s} kind %s to %s", file_id, ie.kind, dest)
+                mutter("  export {%s} kind %s to %s", tp, ie.kind, dest)
 
                 # zipfile.ZipFile switches all paths to forward
                 # slashes anyway, so just stick with that.
                 if force_mtime is not None:
                     mtime = force_mtime
                 else:
-                    mtime = tree.get_file_mtime(tp, file_id)
+                    mtime = tree.get_file_mtime(tp)
                 date_time = time.localtime(mtime)[:6]
                 filename = osutils.pathjoin(root, dp)
                 if ie.kind == "file":
@@ -73,7 +72,7 @@ def zip_archive_generator(tree, dest, root, subdir=None,
                                 date_time=date_time)
                     zinfo.compress_type = compression
                     zinfo.external_attr = _FILE_ATTR
-                    content = tree.get_file_text(tp, file_id)
+                    content = tree.get_file_text(tp)
                     zipf.writestr(zinfo, content)
                 elif ie.kind in ("directory", "tree-reference"):
                     # Directories must contain a trailing slash, to indicate
@@ -91,7 +90,7 @@ def zip_archive_generator(tree, dest, root, subdir=None,
                                 date_time=date_time)
                     zinfo.compress_type = compression
                     zinfo.external_attr = _FILE_ATTR
-                    zipf.writestr(zinfo, tree.get_symlink_target(tp, file_id))
+                    zipf.writestr(zinfo, tree.get_symlink_target(tp))
         # Urgh, headers are written last since they include e.g. file size.
         # So we have to buffer it all :(
         buf.seek(0)

--- a/breezy/branch.py
+++ b/breezy/branch.py
@@ -1401,7 +1401,7 @@ class Branch(controldir.ControlComponent):
             for path, file_id in basis_tree.iter_references():
                 reference_parent = self.reference_parent(path, file_id)
                 reference_parent.create_checkout(tree.abspath(path),
-                    basis_tree.get_reference_revision(path, file_id),
+                    basis_tree.get_reference_revision(path),
                     lightweight)
         return tree
 

--- a/breezy/builtins.py
+++ b/breezy/builtins.py
@@ -3423,9 +3423,9 @@ class cmd_cat(Command):
             from .filter_tree import ContentFilterTree
             filter_tree = ContentFilterTree(rev_tree,
                 rev_tree._content_filter_stack)
-            fileobj = filter_tree.get_file(relpath, actual_file_id)
+            fileobj = filter_tree.get_file(relpath)
         else:
-            fileobj = rev_tree.get_file(relpath, actual_file_id)
+            fileobj = rev_tree.get_file(relpath)
         shutil.copyfileobj(fileobj, self.outf)
         self.cleanup_now()
 
@@ -5220,10 +5220,10 @@ class cmd_annotate(Command):
             # If there is a tree and we're not annotating historical
             # versions, annotate the working tree's content.
             annotate_file_tree(wt, relpath, self.outf, long, all,
-                show_ids=show_ids, file_id=file_id)
+                               show_ids=show_ids)
         else:
             annotate_file_tree(tree, relpath, self.outf, long, all,
-                show_ids=show_ids, branch=branch, file_id=file_id)
+                               show_ids=show_ids, branch=branch)
 
 
 class cmd_re_sign(Command):
@@ -5633,11 +5633,10 @@ class cmd_split(Command):
 
     def run(self, tree):
         containing_tree, subdir = WorkingTree.open_containing(tree)
-        sub_id = containing_tree.path2id(subdir)
-        if sub_id is None:
+        if not containing_tree.is_versioned(subdir):
             raise errors.NotVersionedError(subdir)
         try:
-            containing_tree.extract(subdir, sub_id)
+            containing_tree.extract(subdir)
         except errors.RootNotRich:
             raise errors.RichRootUpgradeRequired(containing_tree.branch.base)
 

--- a/breezy/bundle/bundle_data.py
+++ b/breezy/bundle/bundle_data.py
@@ -616,28 +616,26 @@ class BundleTree(Tree):
         new_path = self.id2path(file_id)
         return self.base_tree.path2id(new_path)
 
-    def get_file(self, path, file_id=None):
+    def get_file(self, path):
         """Return a file-like object containing the new contents of the
-        file given by file_id.
+        file given by path.
 
         TODO:   It might be nice if this actually generated an entry
                 in the text-store, so that the file contents would
                 then be cached.
         """
-        if file_id is None:
-            file_id = self.path2id(path)
+        file_id = self.path2id(path)
         base_id = self.old_contents_id(file_id)
         if (base_id is not None and
             base_id != self.base_tree.get_root_id()):
             old_path = self.old_path(path)
-            patch_original = self.base_tree.get_file(
-                    old_path, base_id)
+            patch_original = self.base_tree.get_file(old_path)
         else:
             patch_original = None
         file_patch = self.patches.get(path)
         if file_patch is None:
             if (patch_original is None and
-                self.kind(path, file_id) == 'directory'):
+                self.kind(path) == 'directory'):
                 return BytesIO()
             if patch_original is None:
                 raise AssertionError("None: %s" % file_id)
@@ -648,41 +646,41 @@ class BundleTree(Tree):
                 'Malformed patch for %s, %r' % (file_id, file_patch))
         return patched_file(file_patch, patch_original)
 
-    def get_symlink_target(self, path, file_id=None):
+    def get_symlink_target(self, path):
         try:
             return self._targets[path]
         except KeyError:
             old_path = self.old_path(path)
-            return self.base_tree.get_symlink_target(old_path, file_id)
+            return self.base_tree.get_symlink_target(old_path)
 
-    def kind(self, path, file_id=None):
+    def kind(self, path):
         try:
             return self._kinds[path]
         except KeyError:
             old_path = self.old_path(path)
-            return self.base_tree.kind(old_path, file_id)
+            return self.base_tree.kind(old_path)
 
-    def get_file_revision(self, path, file_id=None):
+    def get_file_revision(self, path):
         if path in self._last_changed:
             return self._last_changed[path]
         else:
             old_path = self.old_path(path)
-            return self.base_tree.get_file_revision(old_path, file_id)
+            return self.base_tree.get_file_revision(old_path)
 
-    def is_executable(self, path, file_id=None):
+    def is_executable(self, path):
         if path in self._executable:
             return self._executable[path]
         else:
             old_path = self.old_path(path)
-            return self.base_tree.is_executable(old_path, file_id)
+            return self.base_tree.is_executable(old_path)
 
-    def get_last_changed(self, path, file_id=None):
+    def get_last_changed(self, path):
         if path in self._last_changed:
             return self._last_changed[path]
         old_path = self.old_path(path)
-        return self.base_tree.get_file_revision(old_path, file_id)
+        return self.base_tree.get_file_revision(old_path)
 
-    def get_size_and_sha1(self, new_path, file_id=None):
+    def get_size_and_sha1(self, new_path):
         """Return the size and sha1 hash of the given file id.
         If the file was not locally modified, this is extracted
         from the base_tree. Rather than re-reading the file.
@@ -693,10 +691,10 @@ class BundleTree(Tree):
             # If the entry does not have a patch, then the
             # contents must be the same as in the base_tree
             base_path = self.old_path(new_path)
-            text_size = self.base_tree.get_file_size(base_path, file_id)
-            text_sha1 = self.base_tree.get_file_sha1(base_path, file_id)
+            text_size = self.base_tree.get_file_size(base_path)
+            text_sha1 = self.base_tree.get_file_sha1(base_path)
             return text_size, text_sha1
-        fileobj = self.get_file(new_path, file_id)
+        fileobj = self.get_file(new_path)
         content = fileobj.read()
         return len(content), sha_string(content)
 
@@ -715,23 +713,23 @@ class BundleTree(Tree):
                 parent_path = dirname(path)
                 parent_id = self.path2id(parent_path)
 
-            kind = self.kind(path, file_id)
-            revision_id = self.get_last_changed(path, file_id)
+            kind = self.kind(path)
+            revision_id = self.get_last_changed(path)
 
             name = basename(path)
             if kind == 'directory':
                 ie = InventoryDirectory(file_id, name, parent_id)
             elif kind == 'file':
                 ie = InventoryFile(file_id, name, parent_id)
-                ie.executable = self.is_executable(path, file_id)
+                ie.executable = self.is_executable(path)
             elif kind == 'symlink':
                 ie = InventoryLink(file_id, name, parent_id)
-                ie.symlink_target = self.get_symlink_target(path, file_id)
+                ie.symlink_target = self.get_symlink_target(path)
             ie.revision = revision_id
 
             if kind == 'file':
                 ie.text_size, ie.text_sha1 = self.get_size_and_sha1(
-                        path, file_id)
+                        path)
                 if ie.text_size is None:
                     raise BzrError(
                         'Got a text_size of None for file_id %r' % file_id)

--- a/breezy/bundle/bundle_data.py
+++ b/breezy/bundle/bundle_data.py
@@ -618,7 +618,7 @@ class BundleTree(Tree):
 
     def get_file(self, path):
         """Return a file-like object containing the new contents of the
-        file given by path.
+        file given by file_id.
 
         TODO:   It might be nice if this actually generated an entry
                 in the text-store, so that the file contents would
@@ -680,7 +680,7 @@ class BundleTree(Tree):
         old_path = self.old_path(path)
         return self.base_tree.get_file_revision(old_path)
 
-    def get_size_and_sha1(self, new_path):
+    def get_size_and_sha1(self, new_path, file_id=None):
         """Return the size and sha1 hash of the given file id.
         If the file was not locally modified, this is extracted
         from the base_tree. Rather than re-reading the file.
@@ -728,8 +728,7 @@ class BundleTree(Tree):
             ie.revision = revision_id
 
             if kind == 'file':
-                ie.text_size, ie.text_sha1 = self.get_size_and_sha1(
-                        path)
+                ie.text_size, ie.text_sha1 = self.get_size_and_sha1(path)
                 if ie.text_size is None:
                     raise BzrError(
                         'Got a text_size of None for file_id %r' % file_id)

--- a/breezy/bundle/serializer/v08.py
+++ b/breezy/bundle/serializer/v08.py
@@ -272,7 +272,7 @@ class BundleSerializerV08(BundleSerializer):
 
         def do_diff(file_id, old_path, new_path, action, force_binary):
             def tree_lines(tree, path, require_text=False):
-                if tree.has_filename(path):
+                if tree.has_id(file_id):
                     tree_file = tree.get_file(path)
                     if require_text is True:
                         tree_file = text_file(tree_file)
@@ -338,7 +338,7 @@ class BundleSerializerV08(BundleSerializer):
             new_rev = new_tree.get_file_revision(path)
             if new_rev is None:
                 continue
-            old_rev = old_tree.get_file_revision(path)
+            old_rev = old_tree.get_file_revision(old_tree.id2path(file_id))
             if new_rev != old_rev:
                 action = Action('modified', [new_tree.kind(path),
                                              path])

--- a/breezy/bundle/serializer/v08.py
+++ b/breezy/bundle/serializer/v08.py
@@ -272,8 +272,8 @@ class BundleSerializerV08(BundleSerializer):
 
         def do_diff(file_id, old_path, new_path, action, force_binary):
             def tree_lines(tree, path, require_text=False):
-                if tree.has_id(file_id):
-                    tree_file = tree.get_file(path, file_id)
+                if tree.has_filename(path):
+                    tree_file = tree.get_file(path)
                     if require_text is True:
                         tree_file = text_file(tree_file)
                     return tree_file.readlines()
@@ -318,7 +318,7 @@ class BundleSerializerV08(BundleSerializer):
         for path, file_id, kind in delta.added:
             action = Action('added', [kind, path], [('file-id', file_id.decode('utf-8'))])
             meta_modified = (kind=='file' and
-                             new_tree.is_executable(path, file_id))
+                             new_tree.is_executable(path))
             finish_action(action, file_id, kind, meta_modified, True,
                           DEVNULL, path)
 
@@ -335,12 +335,12 @@ class BundleSerializerV08(BundleSerializer):
                           path, path)
 
         for path, file_id, kind in delta.unchanged:
-            new_rev = new_tree.get_file_revision(path, file_id)
+            new_rev = new_tree.get_file_revision(path)
             if new_rev is None:
                 continue
-            old_rev = old_tree.get_file_revision(old_tree.id2path(file_id), file_id)
+            old_rev = old_tree.get_file_revision(path)
             if new_rev != old_rev:
-                action = Action('modified', [new_tree.kind(path, file_id),
+                action = Action('modified', [new_tree.kind(path),
                                              path])
                 action.add_utf8_property('last-changed', new_rev)
                 action.write(self.to_file)

--- a/breezy/bzr/bzrdir.py
+++ b/breezy/bzr/bzrdir.py
@@ -476,7 +476,7 @@ class BzrDir(controldir.ControlDir):
                 target = urlutils.join(url, urlutils.escape(path))
                 sublocation = source_branch.reference_parent(path, file_id)
                 sublocation.controldir.sprout(target,
-                    basis.get_reference_revision(path, file_id),
+                    basis.get_reference_revision(path),
                     force_new_repo=force_new_repo, recurse=recurse,
                     stacked=stacked)
         return result

--- a/breezy/bzr/smart/repository.py
+++ b/breezy/bzr/smart/repository.py
@@ -1374,6 +1374,6 @@ class SmartServerRepositoryAnnotateFileRevision(SmartServerRepositoryRequest):
         tree = repository.revision_tree(revision_id)
         with tree.lock_read():
             body = bencode.bencode(list(tree.annotate_iter(
-                        tree_path.decode('utf-8'), file_id, default_revision)))
+                        tree_path.decode('utf-8'), default_revision)))
             return SuccessfulSmartServerResponse((b'ok',),
                 body=body)

--- a/breezy/bzr/vf_repository.py
+++ b/breezy/bzr/vf_repository.py
@@ -481,7 +481,7 @@ class VersionedFileCommitBuilder(CommitBuilder):
                             nostore_sha = parent_entry.text_sha1
                     else:
                         nostore_sha = None
-                    file_obj, stat_value = tree.get_file_with_stat(change[1][1], file_id)
+                    file_obj, stat_value = tree.get_file_with_stat(change[1][1])
                     try:
                         entry.text_sha1, entry.text_size = self._add_file_to_weave(
                             file_id, file_obj, heads, nostore_sha)
@@ -496,7 +496,7 @@ class VersionedFileCommitBuilder(CommitBuilder):
                         file_obj.close()
                 elif kind == 'symlink':
                     # Wants a path hint?
-                    entry.symlink_target = tree.get_symlink_target(change[1][1], file_id)
+                    entry.symlink_target = tree.get_symlink_target(change[1][1])
                     if (carry_over_possible and
                         parent_entry.symlink_target == entry.symlink_target):
                         carried_over = True
@@ -518,7 +518,7 @@ class VersionedFileCommitBuilder(CommitBuilder):
                         # references.
                         raise errors.UnsupportedOperation(tree.add_reference,
                             self.repository)
-                    reference_revision = tree.get_reference_revision(change[1][1], change[0])
+                    reference_revision = tree.get_reference_revision(change[1][1])
                     entry.reference_revision = reference_revision
                     if (carry_over_possible and
                         parent_entry.reference_revision == reference_revision):
@@ -2853,12 +2853,13 @@ def _install_revision(repository, rev, revision_tree, signature,
             if not tree.has_id(ie.file_id):
                 continue
             path = tree.id2path(ie.file_id)
-            parent_id = tree.get_file_revision(path, ie.file_id)
+            parent_id = tree.get_file_revision(path)
             if parent_id in text_parents:
                 continue
             text_parents.append((ie.file_id, parent_id))
         revision_tree_path = revision_tree.id2path(ie.file_id)
-        lines = revision_tree.get_file(revision_tree_path, ie.file_id).readlines()
+        with revision_tree.get_file(revision_tree_path) as f:
+            lines = f.readlines()
         repository.texts.add_lines(text_key, text_parents, lines)
     try:
         # install the inventory

--- a/breezy/bzr/workingtree_3.py
+++ b/breezy/bzr/workingtree_3.py
@@ -82,10 +82,10 @@ class PreDirStateWorkingTree(InventoryWorkingTree):
                 trace.mutter('Could not write hashcache for %s\nError: %s',
                               self._hashcache.cache_file_name(), e)
 
-    def get_file_sha1(self, path, file_id=None, stat_value=None):
+    def get_file_sha1(self, path, stat_value=None):
         with self.lock_read():
             # To make sure NoSuchFile gets raised..
-            if self.path2id(path) is None:
+            if not self.is_versioned(path):
                 raise errors.NoSuchFile(path)
             return self._hashcache.get_sha1(path, stat_value)
 

--- a/breezy/commit.py
+++ b/breezy/commit.py
@@ -677,7 +677,7 @@ class Commit(object):
         iter_changes = self._filter_iter_changes(iter_changes)
         for file_id, path, fs_hash in self.builder.record_iter_changes(
             self.work_tree, self.basis_revid, iter_changes):
-            self.work_tree._observed_sha1(file_id, path, fs_hash)
+            self.work_tree._observed_sha1(path, fs_hash)
 
     def _filter_iter_changes(self, iter_changes):
         """Process iter_changes.
@@ -711,7 +711,7 @@ class Commit(object):
                 versioned = False
             elif kind == 'tree-reference':
                 if self.recursive == 'down':
-                    self._commit_nested_tree(change[0], change[1][1])
+                    self._commit_nested_tree(change[1][1])
             if change[3][0] or change[3][1]:
                 yield change
                 if report_changes:
@@ -740,9 +740,9 @@ class Commit(object):
             for unknown in self.work_tree.unknowns():
                 raise StrictCommitFailed()
 
-    def _commit_nested_tree(self, file_id, path):
+    def _commit_nested_tree(self, path):
         "Commit a nested tree."
-        sub_tree = self.work_tree.get_nested_tree(path, file_id)
+        sub_tree = self.work_tree.get_nested_tree(path)
         # FIXME: be more comprehensive here:
         # this works when both trees are in --trees repository,
         # but when both are bound to a different repository,
@@ -763,7 +763,7 @@ class Commit(object):
                 strict=self.strict, verbose=self.verbose,
                 local=self.local, reporter=self.reporter)
         except PointlessCommit:
-            return self.work_tree.get_reference_revision(path, file_id)
+            return self.work_tree.get_reference_revision(path)
 
     def _set_progress_stage(self, name, counter=False):
         """Set the progress stage and emit an update to the progress bar."""

--- a/breezy/diff.py
+++ b/breezy/diff.py
@@ -477,7 +477,7 @@ def show_diff_trees(old_tree, new_tree, to_file, specific_files=None,
 def _patch_header_date(tree, file_id, path):
     """Returns a timestamp suitable for use in a patch header."""
     try:
-        mtime = tree.get_file_mtime(path, file_id)
+        mtime = tree.get_file_mtime(path)
     except FileTimestampUnavailable:
         mtime = 0
     return timestamp.format_patch_date(mtime)
@@ -597,13 +597,13 @@ class DiffSymlink(DiffPath):
         if 'symlink' not in (old_kind, new_kind):
             return self.CANNOT_DIFF
         if old_kind == 'symlink':
-            old_target = self.old_tree.get_symlink_target(old_path, file_id)
+            old_target = self.old_tree.get_symlink_target(old_path)
         elif old_kind is None:
             old_target = None
         else:
             return self.CANNOT_DIFF
         if new_kind == 'symlink':
-            new_target = self.new_tree.get_symlink_target(new_path, file_id)
+            new_target = self.new_tree.get_symlink_target(new_path)
         elif new_kind is None:
             new_target = None
         else:
@@ -690,7 +690,7 @@ class DiffText(DiffPath):
         def _get_text(tree, file_id, path):
             if file_id is None:
                 return []
-            return tree.get_file_lines(path, file_id)
+            return tree.get_file_lines(path)
         try:
             from_text = _get_text(self.old_tree, from_file_id, from_path)
             to_text = _get_text(self.new_tree, to_file_id, to_path)
@@ -815,14 +815,14 @@ class DiffFromTool(DiffPath):
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
-        source = tree.get_file(relpath, file_id)
+        source = tree.get_file(relpath)
         try:
             with open(full_path, 'wb') as target:
                 osutils.pumpfile(source, target)
         finally:
             source.close()
         try:
-            mtime = tree.get_file_mtime(relpath, file_id)
+            mtime = tree.get_file_mtime(relpath)
         except FileTimestampUnavailable:
             pass
         else:
@@ -1035,11 +1035,11 @@ class DiffTree(object):
         if old_path is None:
             old_kind = None
         else:
-            old_kind = self.old_tree.kind(old_path, file_id)
+            old_kind = self.old_tree.kind(old_path)
         if new_path is None:
             new_kind = None
         else:
-            new_kind = self.new_tree.kind(new_path, file_id)
+            new_kind = self.new_tree.kind(new_path)
         self._diff(old_path, new_path, old_kind, new_kind, file_id=file_id)
 
     def _diff(self, old_path, new_path, old_kind, new_kind, file_id):

--- a/breezy/export.py
+++ b/breezy/export.py
@@ -197,7 +197,7 @@ def dir_exporter_generator(tree, dest, root, subdir=None,
             os.mkdir(fullpath)
         elif ie.kind == "symlink":
             try:
-                symlink_target = tree.get_symlink_target(tp, file_id)
+                symlink_target = tree.get_symlink_target(tp)
                 os.symlink(symlink_target, fullpath)
             except OSError as e:
                 raise errors.BzrError(
@@ -215,14 +215,14 @@ def dir_exporter_generator(tree, dest, root, subdir=None,
         fullpath = osutils.pathjoin(dest, relpath)
         # We set the mode and let the umask sort out the file info
         mode = 0o666
-        if tree.is_executable(treepath, file_id):
+        if tree.is_executable(treepath):
             mode = 0o777
         with os.fdopen(os.open(fullpath, flags, mode), 'wb') as out:
             out.writelines(chunks)
         if force_mtime is not None:
             mtime = force_mtime
         else:
-            mtime = tree.get_file_mtime(treepath, file_id)
+            mtime = tree.get_file_mtime(treepath)
         os.utime(fullpath, (mtime, mtime))
 
         yield

--- a/breezy/fetch.py
+++ b/breezy/fetch.py
@@ -211,7 +211,7 @@ class Inter1and2Helper(object):
         revision_root = {}
         for tree in self.iter_rev_trees(revs):
             root_id = tree.get_root_id()
-            revision_id = tree.get_file_revision(u'', root_id)
+            revision_id = tree.get_file_revision(u'')
             revision_root[revision_id] = root_id
         # Find out which parents we don't already know root ids for
         parents = set(viewvalues(parent_map))
@@ -317,7 +317,7 @@ def _parent_keys_for_root_version(
                 pass
             else:
                 try:
-                    parent_ids.append(tree.get_file_revision(tree.id2path(root_id), root_id))
+                    parent_ids.append(tree.get_file_revision(tree.id2path(root_id)))
                 except errors.NoSuchId:
                     # not in the tree
                     pass

--- a/breezy/filter_tree.py
+++ b/breezy/filter_tree.py
@@ -46,22 +46,22 @@ class ContentFilterTree(tree.Tree):
         self.backing_tree = backing_tree
         self.filter_stack_callback = filter_stack_callback
 
-    def get_file_text(self, path, file_id=None):
-        chunks = self.backing_tree.get_file_lines(path, file_id)
+    def get_file_text(self, path):
+        chunks = self.backing_tree.get_file_lines(path)
         filters = self.filter_stack_callback(path)
         context = ContentFilterContext(path, self)
         contents = filtered_output_bytes(chunks, filters, context)
         content = b''.join(contents)
         return content
 
-    def get_file(self, path, file_id=None):
-        return BytesIO(self.get_file_text(path, file_id))
+    def get_file(self, path):
+        return BytesIO(self.get_file_text(path))
 
     def has_filename(self, filename):
         return self.backing_tree.has_filename
 
-    def is_executable(self, path, file_id=None):
-        return self.backing_tree.is_executable(path, file_id)
+    def is_executable(self, path):
+        return self.backing_tree.is_executable(path)
 
     def iter_entries_by_dir(self, specific_files=None):
         # NB: This simply returns the parent tree's entries; the length may be

--- a/breezy/git/commit.py
+++ b/breezy/git/commit.py
@@ -113,7 +113,7 @@ class GitCommitBuilder(CommitBuilder):
             if kind[1] == "file":
                 entry.executable = executable[1]
                 blob = Blob()
-                f, st = workingtree.get_file_with_stat(path[1], file_id)
+                f, st = workingtree.get_file_with_stat(path[1])
                 try:
                     blob.data = f.read()
                 finally:
@@ -123,7 +123,7 @@ class GitCommitBuilder(CommitBuilder):
                 self.store.add_object(blob)
                 sha = blob.id
             elif kind[1] == "symlink":
-                symlink_target = workingtree.get_symlink_target(path[1], file_id)
+                symlink_target = workingtree.get_symlink_target(path[1])
                 blob = Blob()
                 blob.data = symlink_target.encode("utf-8")
                 self.store.add_object(blob)
@@ -132,7 +132,7 @@ class GitCommitBuilder(CommitBuilder):
                 st = None
             elif kind[1] == "tree-reference":
                 sha = read_submodule_head(workingtree.abspath(path[1]))
-                reference_revision = workingtree.get_reference_revision(path[1], file_id)
+                reference_revision = workingtree.get_reference_revision(path[1])
                 entry.reference_revision = reference_revision
                 st = None
             else:

--- a/breezy/git/fetch.py
+++ b/breezy/git/fetch.py
@@ -145,15 +145,15 @@ def import_git_blob(texts, mapping, path, name, hexshas,
             ppath = ptree.id2path(file_id)
         except errors.NoSuchId:
             continue
-        pkind = ptree.kind(ppath, file_id)
+        pkind = ptree.kind(ppath)
         if (pkind == ie.kind and
-            ((pkind == "symlink" and ptree.get_symlink_target(ppath, file_id) == ie.symlink_target) or
-             (pkind == "file" and ptree.get_file_sha1(ppath, file_id) == ie.text_sha1 and
-                ptree.is_executable(ppath, file_id) == ie.executable))):
+            ((pkind == "symlink" and ptree.get_symlink_target(ppath) == ie.symlink_target) or
+             (pkind == "file" and ptree.get_file_sha1(ppath) == ie.text_sha1 and
+                ptree.is_executable(ppath) == ie.executable))):
             # found a revision in one of the parents to use
-            ie.revision = ptree.get_file_revision(ppath, file_id)
+            ie.revision = ptree.get_file_revision(ppath)
             break
-        parent_key = (file_id, ptree.get_file_revision(ppath, file_id))
+        parent_key = (file_id, ptree.get_file_revision(ppath))
         if not parent_key in parent_keys:
             parent_keys.append(parent_key)
     if ie.revision is None:

--- a/breezy/git/object_store.py
+++ b/breezy/git/object_store.py
@@ -303,7 +303,7 @@ def _tree_to_objects(tree, parent_trees, idmap, unusual_modes,
         obj.chunked = chunks
         if add_cache_entry is not None:
             add_cache_entry(obj, (file_id, tree.get_file_revision(path)), path)
-        yield path, obj, (file_id, tree.get_file_revision(path, file_id))
+        yield path, obj, (file_id, tree.get_file_revision(path))
         shamap[path] = obj.id
 
     for path in unusual_modes:

--- a/breezy/git/workingtree.py
+++ b/breezy/git/workingtree.py
@@ -608,7 +608,7 @@ class GitWorkingTree(MutableGitIndexTree,workingtree.WorkingTree):
         else:
             return True
 
-    def get_file_mtime(self, path, file_id=None):
+    def get_file_mtime(self, path):
         """See Tree.get_file_mtime."""
         try:
             return self._lstat(path).st_mtime
@@ -677,7 +677,7 @@ class GitWorkingTree(MutableGitIndexTree,workingtree.WorkingTree):
                 self.store.__getitem__, self.store[head].tree)
         self._fileid_map = self._basis_fileid_map.copy()
 
-    def get_file_verifier(self, path, file_id=None, stat_value=None):
+    def get_file_verifier(self, path, stat_value=None):
         with self.lock_read():
             (index, subpath) = self._lookup_index(path.encode('utf-8'))
             try:
@@ -687,7 +687,7 @@ class GitWorkingTree(MutableGitIndexTree,workingtree.WorkingTree):
                     return ("GIT", None)
                 raise errors.NoSuchFile(path)
 
-    def get_file_sha1(self, path, file_id=None, stat_value=None):
+    def get_file_sha1(self, path, stat_value=None):
         with self.lock_read():
             if not self.is_versioned(path):
                 raise errors.NoSuchFile(path)
@@ -709,7 +709,7 @@ class GitWorkingTree(MutableGitIndexTree,workingtree.WorkingTree):
     def _is_executable_from_path_and_stat_from_basis(self, path, stat_result):
         return self.basis_tree().is_executable(path)
 
-    def stored_kind(self, path, file_id=None):
+    def stored_kind(self, path):
         with self.lock_read():
             encoded_path = path.encode('utf-8')
             (index, subpath) = self._lookup_index(encoded_path)
@@ -727,7 +727,7 @@ class GitWorkingTree(MutableGitIndexTree,workingtree.WorkingTree):
     def _live_entry(self, path):
         return index_entry_from_path(self.abspath(path.decode('utf-8')).encode(osutils._fs_enc))
 
-    def is_executable(self, path, file_id=None):
+    def is_executable(self, path):
         with self.lock_read():
             if getattr(self, "_supports_executable", osutils.supports_executable)():
                 mode = self._lstat(path).st_mode
@@ -831,7 +831,7 @@ class GitWorkingTree(MutableGitIndexTree,workingtree.WorkingTree):
                     paths.add(path)
             return paths
 
-    def iter_child_entries(self, path, file_id=None):
+    def iter_child_entries(self, path):
         encoded_path = path.encode('utf-8')
         with self.lock_read():
             parent_id = self.path2id(path)
@@ -1074,7 +1074,7 @@ class GitWorkingTree(MutableGitIndexTree,workingtree.WorkingTree):
                     self._index_add_entry(new_path, ie.kind)
         self.flush()
 
-    def annotate_iter(self, path, file_id=None,
+    def annotate_iter(self, path,
                       default_revision=_mod_revision.CURRENT_REVISION):
         """See Tree.annotate_iter
 
@@ -1212,13 +1212,13 @@ class GitWorkingTree(MutableGitIndexTree,workingtree.WorkingTree):
     def _read_submodule_head(self, path):
         return read_submodule_head(self.abspath(path))
 
-    def get_reference_revision(self, path, file_id=None):
+    def get_reference_revision(self, path):
         hexsha = self._read_submodule_head(path)
         if hexsha is None:
             return _mod_revision.NULL_REVISION
         return self.branch.lookup_foreign_revision_id(hexsha)
 
-    def get_nested_tree(self, path, file_id=None):
+    def get_nested_tree(self, path):
         return workingtree.WorkingTree.open(self.abspath(path))
 
     def _directory_is_tree_reference(self, relpath):
@@ -1226,7 +1226,7 @@ class GitWorkingTree(MutableGitIndexTree,workingtree.WorkingTree):
         # it's a tree reference, except that the root of the tree is not
         return relpath and osutils.lexists(self.abspath(relpath) + u"/.git")
 
-    def extract(self, sub_path, file_id=None, format=None):
+    def extract(self, sub_path, format=None):
         """Extract a subtree from this tree.
 
         A new branch will be created, relative to the path for this tree.

--- a/breezy/log.py
+++ b/breezy/log.py
@@ -2131,7 +2131,7 @@ def _get_info_for_log_files(revisionspec_list, file_list, add_cleanup):
 def _get_kind_for_file_id(tree, path, file_id):
     """Return the kind of a file-id or None if it doesn't exist."""
     if file_id is not None:
-        return tree.kind(path, file_id)
+        return tree.kind(path)
     else:
         return None
 

--- a/breezy/memorytree.py
+++ b/breezy/memorytree.py
@@ -144,8 +144,8 @@ class MemoryTree(MutableInventoryTree):
         """See Tree.has_filename()."""
         return self._file_transport.has(filename)
 
-    def is_executable(self, path, file_id=None):
-        return self._inventory[file_id].executable
+    def is_executable(self, path):
+        return self._inventory.get_entry_by_path(path).executable
 
     def kind(self, path, file_id=None):
         if file_id is None:
@@ -230,7 +230,7 @@ class MemoryTree(MutableInventoryTree):
                 self._file_transport.mkdir(path)
             elif entry.kind == 'file':
                 self._file_transport.put_file(path,
-                    self._basis_tree.get_file(path, entry.file_id))
+                    self._basis_tree.get_file(path))
             else:
                 raise NotImplementedError(self._populate_from_branch)
 

--- a/breezy/merge.py
+++ b/breezy/merge.py
@@ -640,9 +640,9 @@ class Merger(object):
             hook(merge)
         if self.recurse == 'down':
             for relpath, file_id in self.this_tree.iter_references():
-                sub_tree = self.this_tree.get_nested_tree(relpath, file_id)
+                sub_tree = self.this_tree.get_nested_tree(relpath)
                 other_revision = self.other_tree.get_reference_revision(
-                    relpath, file_id)
+                    relpath)
                 if  other_revision == sub_tree.last_revision():
                     continue
                 sub_merge = Merger(sub_tree.branch, this_tree=sub_tree)
@@ -653,7 +653,7 @@ class Merger(object):
                 base_tree_path = _mod_tree.find_previous_path(
                     self.this_tree, self.base_tree, relpath)
                 base_revision = self.base_tree.get_reference_revision(
-                    base_tree_path, file_id)
+                    base_tree_path)
                 sub_merge.base_tree = \
                     sub_tree.branch.repository.revision_tree(base_revision)
                 sub_merge.base_rev_id = base_revision
@@ -996,7 +996,7 @@ class Merge3Merger(object):
                         if path is None:
                             return None
                         try:
-                            return tree.get_file_sha1(path, file_id)
+                            return tree.get_file_sha1(path)
                         except errors.NoSuchFile:
                             return None
                     base_sha1 = get_sha1(self.base_tree, base_path)
@@ -1022,7 +1022,7 @@ class Merge3Merger(object):
                     def get_target(ie, tree, path):
                         if ie.kind != 'symlink':
                             return None
-                        return tree.get_symlink_target(path, file_id)
+                        return tree.get_symlink_target(path)
                     base_target = get_target(base_ie, self.base_tree, base_path)
                     lca_targets = [get_target(ie, tree, lca_path) for ie, tree, lca_path
                                    in zip(lca_entries, self._lca_trees, lca_paths)]
@@ -1071,7 +1071,7 @@ class Merge3Merger(object):
             file_id = self.working_tree.path2id(wt_relpath)
             if file_id is None:
                 continue
-            hash = self.working_tree.get_file_sha1(wt_relpath, file_id)
+            hash = self.working_tree.get_file_sha1(wt_relpath)
             if hash is None:
                 continue
             modified_hashes[file_id] = hash
@@ -1107,7 +1107,7 @@ class Merge3Merger(object):
                 return False
         except errors.NoSuchFile:
             return None
-        return tree.is_executable(path, file_id)
+        return tree.is_executable(path)
 
     @staticmethod
     def kind(tree, path, file_id=None):
@@ -1258,13 +1258,13 @@ class Merge3Merger(object):
             if path is None:
                 return (None, None)
             try:
-                kind = tree.kind(path, file_id)
+                kind = tree.kind(path)
             except errors.NoSuchFile:
                 return (None, None)
             if kind == "file":
-                contents = tree.get_file_sha1(path, file_id)
+                contents = tree.get_file_sha1(path)
             elif kind == "symlink":
-                contents = tree.get_symlink_target(path, file_id)
+                contents = tree.get_symlink_target(path)
             else:
                 contents = None
             return kind, contents
@@ -1427,13 +1427,13 @@ class Merge3Merger(object):
         if path is None:
             return []
         try:
-            kind = tree.kind(path, file_id)
+            kind = tree.kind(path)
         except errors.NoSuchFile:
             return []
         else:
             if kind != 'file':
                 return []
-            return tree.get_file_lines(path, file_id)
+            return tree.get_file_lines(path)
 
     def text_merge(self, trans_id, paths, file_id):
         """Perform a three-way text merge on a file_id"""
@@ -1727,7 +1727,7 @@ class Diff3Merger(Merge3Merger):
     def dump_file(self, temp_dir, name, tree, path, file_id=None):
         out_path = osutils.pathjoin(temp_dir, name)
         with open(out_path, "wb") as out_file:
-            in_file = tree.get_file(path, file_id=None)
+            in_file = tree.get_file(path)
             for line in in_file:
                 out_file.write(line)
         return out_path

--- a/breezy/mutabletree.py
+++ b/breezy/mutabletree.py
@@ -289,7 +289,7 @@ class MutableTree(tree.Tree):
         """
         raise NotImplementedError(self.mkdir)
 
-    def _observed_sha1(self, file_id, path, sha_and_stat):
+    def _observed_sha1(self, path, sha_and_stat):
         """Tell the tree we have observed a paths sha1.
 
         The intent of this function is to allow trees that have a hashcache to
@@ -299,7 +299,6 @@ class MutableTree(tree.Tree):
 
         The default implementation does nothing.
 
-        :param file_id: The file id
         :param path: The file path
         :param sha_and_stat: The sha 1 and stat result observed.
         :return: None

--- a/breezy/plugins/commitfromnews/committemplate.py
+++ b/breezy/plugins/commitfromnews/committemplate.py
@@ -68,8 +68,7 @@ class CommitTemplate(object):
             # final diff: because we want to grab the sections for regions 
             # changed in new version of the file. So for now a direct diff
             # using patiencediff is done.
-            old_revision = self.commit.basis_tree.get_file_revision(
-                old_path, found_entry.file_id)
+            old_revision = self.commit.basis_tree.get_file_revision(old_path)
             needed = [(found_entry.file_id, found_entry.revision, 'new'),
                       (found_entry.file_id, old_revision, 'old')]
             contents = self.commit.builder.repository.iter_files_bytes(needed)

--- a/breezy/plugins/fastimport/exporter.py
+++ b/breezy/plugins/fastimport/exporter.py
@@ -494,15 +494,15 @@ class BzrFastExporter(object):
         # Record modifications
         for path, id_, kind in changes.added + my_modified + rd_modifies:
             if kind == 'file':
-                text = tree_new.get_file_text(path, id_)
+                text = tree_new.get_file_text(path)
                 file_cmds.append(commands.FileModifyCommand(path.encode("utf-8"),
                     helpers.kind_to_mode(
-                        'file', tree_new.is_executable(path, id_)),
+                        'file', tree_new.is_executable(path)),
                     None, text))
             elif kind == 'symlink':
                 file_cmds.append(commands.FileModifyCommand(path.encode("utf-8"),
                     helpers.kind_to_mode('symlink', False),
-                    None, tree_new.get_symlink_target(path, id_)))
+                    None, tree_new.get_symlink_target(path)))
             elif kind == 'directory':
                 if not self.plain_format:
                     file_cmds.append(

--- a/breezy/plugins/fastimport/revision_store.py
+++ b/breezy/plugins/fastimport/revision_store.py
@@ -46,6 +46,8 @@ class _TreeShim(object):
         self._inv_delta = inv_delta
         self._new_info_by_id = dict([(file_id, (new_path, ie))
                                     for _, new_path, file_id, ie in inv_delta])
+        self._new_info_by_path = {new_path: ie
+                                  for _, new_path, file_id, ie in inv_delta}
 
     def id2path(self, file_id):
         if file_id in self._new_info_by_id:
@@ -61,19 +63,18 @@ class _TreeShim(object):
         # need more than just root, is to defer to basis_inv.path2id() and then
         # check if the file_id is in our _new_info_by_id dict. And in that
         # case, return _new_info_by_id[file_id][0]
-        if path != '':
-            raise NotImplementedError(_TreeShim.path2id)
-        # TODO: Handle root renames?
-        return self._basis_inv.root.file_id
+        try:
+            return self._new_info_by_path[path].file_id
+        except KeyError:
+            return self._basis_inv.path2id(path)
 
-    def get_file_with_stat(self, path, file_id=None):
-        content = self.get_file_text(path, file_id)
+    def get_file_with_stat(self, path):
+        content = self.get_file_text(path)
         sio = BytesIO(content)
         return sio, None
 
-    def get_file_text(self, path, file_id=None):
-        if file_id is None:
-            file_id = self.path2id(path)
+    def get_file_text(self, path):
+        file_id = self.path2id(path)
         try:
             return self._content_provider(file_id)
         except KeyError:
@@ -85,15 +86,16 @@ class _TreeShim(object):
                                                         'unordered', True)
             return next(stream).get_bytes_as('fulltext')
 
-    def get_symlink_target(self, path, file_id=None):
-        if file_id is None:
+    def get_symlink_target(self, path):
+        try:
+            ie = self._new_info_by_path[path]
+        except KeyError:
             file_id = self.path2id(path)
-        if file_id in self._new_info_by_id:
-            ie = self._new_info_by_id[file_id][1]
+            return self._basis_inv.get_entry(file_id).symlink_target
+        else:
             return ie.symlink_target
-        return self._basis_inv.get_entry(file_id).symlink_target
 
-    def get_reference_revision(self, path, file_id=None):
+    def get_reference_revision(self, path):
         raise NotImplementedError(_TreeShim.get_reference_revision)
 
     def _delta_to_iter_changes(self):
@@ -227,13 +229,13 @@ class RevisionStore(object):
         """Get the text stored for a file in a given revision."""
         revtree = self.repo.revision_tree(revision_id)
         path = revtree.id2path(file_id)
-        return revtree.get_file_text(path, file_id)
+        return revtree.get_file_text(path)
 
     def get_file_lines(self, revision_id, file_id):
         """Get the lines stored for a file in a given revision."""
         revtree = self.repo.revision_tree(revision_id)
         path = revtree.id2path(file_id)
-        return osutils.split_lines(revtree.get_file_text(path, file_id))
+        return osutils.split_lines(revtree.get_file_text(path))
 
     def start_new_revision(self, revision, parents, parent_invs):
         """Init the metadata needed for get_parents_and_revision_for_entry().

--- a/breezy/plugins/fastimport/tests/test_revision_store.py
+++ b/breezy/plugins/fastimport/tests/test_revision_store.py
@@ -85,9 +85,7 @@ class Test_TreeShim(tests.TestCase):
         shim = revision_store._TreeShim(repo=None, basis_inv=basis_inv,
                                         inv_delta=[], content_provider=None)
         self.assertEqual(b'TREE_ROOT', shim.path2id(''))
-        # We don't want to ever give a wrong value, so for now we just raise
-        # NotImplementedError
-        self.assertRaises(NotImplementedError, shim.path2id, 'bar')
+        self.assertEqual(b'bar-id', shim.path2id('bar'))
 
     def test_get_file_with_stat_content_in_stream(self):
         basis_inv = self.make_trivial_basis_inv()
@@ -98,7 +96,7 @@ class Test_TreeShim(tests.TestCase):
         shim = revision_store._TreeShim(repo=None, basis_inv=basis_inv,
                                         inv_delta=[],
                                         content_provider=content_provider)
-        f_obj, stat_val = shim.get_file_with_stat('bar/baz', b'baz-id')
+        f_obj, stat_val = shim.get_file_with_stat('bar/baz')
         self.assertIs(None, stat_val)
         self.assertEqualDiff(b'content of\nbaz-id\n', f_obj.read())
 
@@ -113,7 +111,7 @@ class Test_TreeShim(tests.TestCase):
         shim = revision_store._TreeShim(repo=None, basis_inv=basis_inv,
                                         inv_delta=[], content_provider=None)
         self.assertEqual(u'link-target',
-                         shim.get_symlink_target('link', b'link-id'))
+                         shim.get_symlink_target('link'))
 
     def test_get_symlink_target_from_delta(self):
         basis_inv = self.make_trivial_basis_inv()
@@ -124,7 +122,7 @@ class Test_TreeShim(tests.TestCase):
                                         inv_delta=inv_delta,
                                         content_provider=None)
         self.assertEqual(u'link-target',
-                         shim.get_symlink_target('link', b'link-id'))
+                         shim.get_symlink_target('link'))
 
     def test__delta_to_iter_changes(self):
         basis_inv = self.make_trivial_basis_inv()

--- a/breezy/plugins/grep/grep.py
+++ b/breezy/plugins/grep/grep.py
@@ -428,7 +428,7 @@ def dir_grep(tree, path, relpath, opts, revno, path_prefix):
                 # If old result is valid, print results immediately.
                 # Otherwise, add file info to to_grep so that the
                 # loop later will get chunks and grep them
-                cache_id = tree.get_file_revision(tree_path, fid)
+                cache_id = tree.get_file_revision(tree_path)
                 if cache_id in outputter.cache:
                     # GZ 2010-06-05: Not really sure caching and re-outputting
                     #                the old path is really the right thing,

--- a/breezy/plugins/upload/cmds.py
+++ b/breezy/plugins/upload/cmds.py
@@ -175,15 +175,15 @@ class BzrUploader(object):
                     dir = os.path.dirname(dir)
         return ignored
 
-    def upload_file(self, old_relpath, new_relpath, id, mode=None):
+    def upload_file(self, old_relpath, new_relpath, mode=None):
         if mode is None:
-            if self.tree.is_executable(new_relpath, id):
+            if self.tree.is_executable(new_relpath):
                 mode = 0o775
             else:
                 mode = 0o664
         if not self.quiet:
             self.outf.write('Uploading %s\n' % old_relpath)
-        self._up_put_bytes(old_relpath, self.tree.get_file_text(new_relpath, id), mode)
+        self._up_put_bytes(old_relpath, self.tree.get_file_text(new_relpath), mode)
 
     def _force_clear(self, relpath):
         try:
@@ -202,14 +202,14 @@ class BzrUploader(object):
         except errors.PathError:
             pass
 
-    def upload_file_robustly(self, relpath, id, mode=None):
+    def upload_file_robustly(self, relpath, mode=None):
         """Upload a file, clearing the way on the remote side.
 
         When doing a full upload, it may happen that a directory exists where
         we want to put our file.
         """
         self._force_clear(relpath)
-        self.upload_file(relpath, relpath, id, mode)
+        self.upload_file(relpath, relpath, mode)
 
     def upload_symlink(self, relpath, target):
         self.to_transport.symlink(target, relpath)
@@ -326,7 +326,7 @@ class BzrUploader(object):
                         self.outf.write('Ignoring %s\n' % relpath)
                     continue
                 if ie.kind == 'file':
-                    self.upload_file_robustly(relpath, ie.file_id)
+                    self.upload_file_robustly(relpath)
                 elif ie.kind == 'symlink':
                     try:
                         self.upload_symlink_robustly(relpath, ie.symlink_target)
@@ -388,7 +388,7 @@ class BzrUploader(object):
                 if content_change:
                     # We update the old_path content because renames and
                     # deletions are differed.
-                    self.upload_file(old_path, new_path, id)
+                    self.upload_file(old_path, new_path)
                 self.rename_remote(old_path, new_path)
             self.finish_renames()
             self.finish_deletions()
@@ -406,7 +406,7 @@ class BzrUploader(object):
                     raise NotImplementedError
 
                 if new_kind == 'file':
-                    self.upload_file(path, path, id)
+                    self.upload_file(path, path)
                 elif new_kind == 'symlink':
                     target = self.tree.get_symlink_target(path)
                     self.upload_symlink(path, target)
@@ -421,7 +421,7 @@ class BzrUploader(object):
                         self.outf.write('Ignoring %s\n' % path)
                     continue
                 if kind == 'file':
-                    self.upload_file(path, path, id)
+                    self.upload_file(path, path)
                 elif kind == 'directory':
                     self.make_remote_dir(path)
                 elif kind == 'symlink':
@@ -443,7 +443,7 @@ class BzrUploader(object):
                         self.outf.write('Ignoring %s\n' % path)
                     continue
                 if kind == 'file':
-                    self.upload_file(path, path, id)
+                    self.upload_file(path, path)
                 elif kind == 'symlink':
                     target = self.tree.get_symlink_target(path)
                     self.upload_symlink(path, target)

--- a/breezy/plugins/weave_fmt/test_bzrdir.py
+++ b/breezy/plugins/weave_fmt/test_bzrdir.py
@@ -337,10 +337,10 @@ class TestUpgrade(TestCaseWithTransport):
         rt = b.repository.revision_tree(rh[0])
         foo_id = b'foo-20051004035605-91e788d1875603ae'
         with rt.lock_read():
-            eq(rt.get_file_text('foo', foo_id), b'initial contents\n')
+            eq(rt.get_file_text('foo'), b'initial contents\n')
         rt = b.repository.revision_tree(rh[1])
         with rt.lock_read():
-            eq(rt.get_file_text('foo', foo_id), b'new contents\n')
+            eq(rt.get_file_text('foo'), b'new contents\n')
         # check a backup was made:
         backup_dir = 'backup.bzr.~1~'
         t = self.get_transport('.')

--- a/breezy/revisiontree.py
+++ b/breezy/revisiontree.py
@@ -62,17 +62,17 @@ class RevisionTree(tree.Tree):
         """Return the revision id associated with this tree."""
         return self._revision_id
 
-    def get_file_revision(self, path, file_id=None):
+    def get_file_revision(self, path):
         """Return the revision id in which a file was last changed."""
         raise NotImplementedError(self.get_file_revision)
 
-    def get_file_text(self, path, file_id=None):
+    def get_file_text(self, path):
         for (identifier, content) in self.iter_files_bytes([(path, None)]):
             ret = b"".join(content)
         return ret
 
-    def get_file(self, path, file_id=None):
-        return BytesIO(self.get_file_text(path, file_id))
+    def get_file(self, path):
+        return BytesIO(self.get_file_text(path))
 
     def is_locked(self):
         return self._repository.is_locked()

--- a/breezy/shelf.py
+++ b/breezy/shelf.py
@@ -125,10 +125,8 @@ class ShelfCreator(object):
                 if kind[0] != kind [1]:
                     yield ('change kind', file_id, kind[0], kind[1], paths[0])
                 elif kind[0] == 'symlink':
-                    t_target = self.target_tree.get_symlink_target(
-                            paths[0], file_id)
-                    w_target = self.work_tree.get_symlink_target(
-                            paths[1], file_id)
+                    t_target = self.target_tree.get_symlink_target(paths[0])
+                    w_target = self.work_tree.get_symlink_target(paths[1])
                     yield ('modify target', file_id, paths[0], t_target,
                             w_target)
                 elif changed:
@@ -181,13 +179,13 @@ class ShelfCreator(object):
             to shelving.
         """
         new_path = self.target_tree.id2path(file_id)
-        new_target = self.target_tree.get_symlink_target(new_path, file_id)
+        new_target = self.target_tree.get_symlink_target(new_path)
         w_trans_id = self.work_transform.trans_id_file_id(file_id)
         self.work_transform.delete_contents(w_trans_id)
         self.work_transform.create_symlink(new_target, w_trans_id)
 
         old_path = self.work_tree.id2path(file_id)
-        old_target = self.work_tree.get_symlink_target(old_path, file_id)
+        old_target = self.work_tree.get_symlink_target(old_path)
         s_trans_id = self.shelf_transform.trans_id_file_id(file_id)
         self.shelf_transform.delete_contents(s_trans_id)
         self.shelf_transform.create_symlink(old_target, s_trans_id)
@@ -277,9 +275,9 @@ class ShelfCreator(object):
     def _inverse_lines(self, new_lines, file_id):
         """Produce a version with only those changes removed from new_lines."""
         target_path = self.target_tree.id2path(file_id)
-        target_lines = self.target_tree.get_file_lines(target_path, file_id)
+        target_lines = self.target_tree.get_file_lines(target_path)
         work_path = self.work_tree.id2path(file_id)
-        work_lines = self.work_tree.get_file_lines(work_path, file_id)
+        work_lines = self.work_tree.get_file_lines(work_path)
         return merge3.Merge3(new_lines, target_lines, work_lines).merge_lines()
 
     def finalize(self):

--- a/breezy/shelf_ui.py
+++ b/breezy/shelf_ui.py
@@ -325,7 +325,7 @@ class Shelver(object):
             target_lines = work_tree_lines
         else:
             path = self.target_tree.id2path(file_id)
-            target_lines = self.target_tree.get_file_lines(path, file_id)
+            target_lines = self.target_tree.get_file_lines(path)
         textfile.check_text_lines(work_tree_lines)
         textfile.check_text_lines(target_lines)
         parsed = self.get_parsed_patch(file_id, self.reporter.invert_diff)

--- a/breezy/tests/blackbox/test_resolve.py
+++ b/breezy/tests/blackbox/test_resolve.py
@@ -177,7 +177,7 @@ class TestResolveAuto(tests.TestCaseWithTransport):
         self.build_tree_contents([('tree/file',
             b'<<<<<<<\na\n=======\n>>>>>>>\n')])
         tree.add('file', b'file_id')
-        self.assertEqual(tree.kind('file', b'file_id'), 'file')
+        self.assertEqual(tree.kind('file'), 'file')
         file_conflict = conflicts.TextConflict('file', file_id=b'file_id')
         tree.set_conflicts(conflicts.ConflictList([file_conflict]))
         note = self.run_bzr('resolve', retcode=1, working_dir='tree')[1]

--- a/breezy/tests/per_intertree/test_file_content_matches.py
+++ b/breezy/tests/per_intertree/test_file_content_matches.py
@@ -32,8 +32,6 @@ class TestFileContentMatches(TestCaseWithTwoTrees):
         tree2.add('file', b'file-id-2')
         tree1, tree2 = self.mutable_trees_to_test_trees(self, tree1, tree2)
         inter = self.intertree_class(tree1, tree2)
-        self.assertTrue(inter.file_content_matches(
-            'file', 'file', b'file-id-1', b'file-id-2'))
         self.assertTrue(inter.file_content_matches('file', 'file'))
 
     def test_different_contents_and_same_verifier(self):
@@ -47,7 +45,5 @@ class TestFileContentMatches(TestCaseWithTwoTrees):
         tree2.add('file', b'file-id-2')
         tree1, tree2 = self.mutable_trees_to_test_trees(self, tree1, tree2)
         inter = self.intertree_class(tree1, tree2)
-        self.assertFalse(inter.file_content_matches(
-            'file', 'file', b'file-id-1', b'file-id-2'))
         self.assertFalse(inter.file_content_matches(
             'file', 'file'))

--- a/breezy/tests/per_repository/test_commit_builder.py
+++ b/breezy/tests/per_repository/test_commit_builder.py
@@ -235,8 +235,7 @@ class TestCommitBuilder(per_repository.TestCaseWithRepository):
 
     def test_revision_tree_record_iter_changes(self):
         tree = self.make_branch_and_tree(".")
-        tree.lock_write()
-        try:
+        with tree.lock_write():
             builder = tree.branch.get_commit_builder([])
             try:
                 list(builder.record_iter_changes(tree,
@@ -252,8 +251,6 @@ class TestCommitBuilder(per_repository.TestCaseWithRepository):
             # the RevisionTree api.
             self.assertEqual(rev_id, rev_tree.get_revision_id())
             self.assertEqual((), tuple(rev_tree.get_parent_ids()))
-        finally:
-            tree.unlock()
 
     def test_root_entry_has_revision(self):
         # test the root revision created and put in the basis
@@ -266,19 +263,15 @@ class TestCommitBuilder(per_repository.TestCaseWithRepository):
         basis_tree = tree.basis_tree()
         basis_tree.lock_read()
         self.addCleanup(basis_tree.unlock)
-        self.assertEqual(rev_id,
-            basis_tree.get_file_revision(u'', basis_tree.get_root_id()))
+        self.assertEqual(rev_id, basis_tree.get_file_revision(u''))
 
     def _get_revtrees(self, tree, revision_ids):
-        tree.lock_read()
-        try:
+        with tree.lock_read():
             trees = list(tree.branch.repository.revision_trees(revision_ids))
             for _tree in trees:
                 _tree.lock_read()
                 self.addCleanup(_tree.unlock)
             return trees
-        finally:
-            tree.unlock()
 
     def test_last_modified_revision_after_commit_root_unchanged(self):
         # commiting without changing the root does not change the
@@ -655,7 +648,7 @@ class TestCommitBuilder(per_repository.TestCaseWithRepository):
             tree3, = self._get_revtrees(in_tree, [rev2])
             self.assertEqual(
                     rev2,
-                    tree3.get_file_revision('new_' + name, file_id))
+                    tree3.get_file_revision('new_' + name))
             expected_graph = {}
             expected_graph[(file_id, rev1)] = ()
             expected_graph[(file_id, rev2)] = ((file_id, rev1),)

--- a/breezy/tests/per_repository/test_fetch.py
+++ b/breezy/tests/per_repository/test_fetch.py
@@ -85,11 +85,8 @@ class TestFetchSameRepository(TestCaseWithRepository):
         # disk.
         knit3_repo = b_bzrdir.open_repository()
         rev1_tree = knit3_repo.revision_tree(rev1)
-        rev1_tree.lock_read()
-        try:
-            lines = rev1_tree.get_file_lines(u'', rev1_tree.get_root_id())
-        finally:
-            rev1_tree.unlock()
+        with rev1_tree.lock_read():
+            lines = rev1_tree.get_file_lines(u'')
         self.assertEqual([], lines)
         b_branch = b_bzrdir.create_branch()
         b_branch.pull(tree_a.branch)
@@ -103,9 +100,7 @@ class TestFetchSameRepository(TestCaseWithRepository):
                               % b_bzrdir.transport)
         rev2 = tree_b.commit('no change')
         rev2_tree = knit3_repo.revision_tree(rev2)
-        self.assertEqual(
-            rev1,
-            rev2_tree.get_file_revision(u'', rev2_tree.get_root_id()))
+        self.assertEqual(rev1, rev2_tree.get_file_revision(u''))
 
     def do_test_fetch_to_rich_root_sets_parents_correctly(self, result,
         snapshots, root_id=ROOT_ID, allow_lefthand_ghost=False):

--- a/breezy/tests/per_repository/test_repository.py
+++ b/breezy/tests/per_repository/test_repository.py
@@ -180,7 +180,7 @@ class TestRepository(per_repository.TestCaseWithRepository):
         rev_tree = tree.branch.repository.revision_tree(second_revision)
         rev_tree.lock_read()
         self.addCleanup(rev_tree.unlock)
-        root_revision = rev_tree.get_file_revision(u'', rev_tree.get_root_id())
+        root_revision = rev_tree.get_file_revision(u'')
         rich_root = (root_revision != second_revision)
         self.assertEqual(rich_root,
                          tree.branch.repository.supports_rich_root())
@@ -290,8 +290,7 @@ class TestRepository(per_repository.TestCaseWithRepository):
         tree = wt.branch.repository.revision_tree(rev1)
         tree.lock_read()
         try:
-            self.assertEqual(rev1,
-                tree.get_file_revision(u'', tree.get_root_id()))
+            self.assertEqual(rev1, tree.get_file_revision(u''))
             expected = inventory.InventoryDirectory(root_id, '', None)
             expected.revision = rev1
             self.assertEqual([('', 'V', 'directory', root_id, expected)],
@@ -481,7 +480,7 @@ class TestRepository(per_repository.TestCaseWithRepository):
         rev_tree.lock_read()
         self.addCleanup(rev_tree.unlock)
         root_id = rev_tree.get_root_id()
-        self.assertEqual(revid, rev_tree.get_file_revision(u'', root_id))
+        self.assertEqual(revid, rev_tree.get_file_revision(u''))
 
     def test_pointless_commit(self):
         tree = self.make_branch_and_tree('.')
@@ -964,7 +963,7 @@ class TestEscaping(tests.TestCaseWithTransport):
         revtree = branch.repository.revision_tree(rev1)
         revtree.lock_read()
         self.addCleanup(revtree.unlock)
-        contents = revtree.get_file_text(revtree.id2path(FOO_ID), FOO_ID)
+        contents = revtree.get_file_text('foo')
         self.assertEqual(contents, b'contents of repo/foo\n')
 
     def test_create_bundle(self):

--- a/breezy/tests/per_repository_vf/test_merge_directive.py
+++ b/breezy/tests/per_repository_vf/test_merge_directive.py
@@ -76,6 +76,5 @@ class TestMergeDirective(TestCaseWithRepository):
         chk_map.clear_cache()
         directive.install_revisions(target_branch.repository)
         rt = target_branch.repository.revision_tree(b'B')
-        rt.lock_read()
-        self.assertEqualDiff(b'new content\n', rt.get_file_text('f', b'f-id'))
-        rt.unlock()
+        with rt.lock_read():
+            self.assertEqualDiff(b'new content\n', rt.get_file_text('f'))

--- a/breezy/tests/per_tree/test_tree.py
+++ b/breezy/tests/per_tree/test_tree.py
@@ -178,13 +178,6 @@ class TestFileContent(TestCaseWithTree):
             self.assertEqual([b'foobar\n'], lines)
         finally:
             file_without_path.close()
-        # Test lookup with path works
-        file_with_path = tree.get_file('a', a_id)
-        try:
-            lines = file_with_path.readlines()
-            self.assertEqual([b'foobar\n'], lines)
-        finally:
-            file_with_path.close()
 
     def test_get_file_context_manager(self):
         work_tree = self.make_branch_and_tree('wt')
@@ -201,8 +194,6 @@ class TestFileContent(TestCaseWithTree):
         a_id = tree.path2id('a')
         tree.lock_read()
         self.addCleanup(tree.unlock)
-        # test read by file-id
-        self.assertEqual(b'foobar\n', tree.get_file_text('a', a_id))
         # test read by path
         self.assertEqual(b'foobar\n', tree.get_file_text('a'))
 
@@ -212,8 +203,6 @@ class TestFileContent(TestCaseWithTree):
         a_id = tree.path2id('a')
         tree.lock_read()
         self.addCleanup(tree.unlock)
-        # test read by file-id
-        self.assertEqual([b'foobar\n'], tree.get_file_lines('a', a_id))
         # test read by path
         self.assertEqual([b'foobar\n'], tree.get_file_lines('a'))
 
@@ -279,11 +268,9 @@ class TestIterChildEntries(TestCaseWithTree):
         self.build_tree(['a/', 'a/b/', 'a/b/c', 'a/d/', 'a/d/e', 'f/', 'f/g'])
         work_tree.add(['a', 'a/b', 'a/b/c', 'a/d', 'a/d/e', 'f', 'f/g'])
         tree = self._convert_tree(work_tree)
-        output = [e.name for e in
-            tree.iter_child_entries('', tree.get_root_id())]
+        output = [e.name for e in tree.iter_child_entries('')]
         self.assertEqual({'a', 'f'}, set(output))
-        output = [e.name for e in
-            tree.iter_child_entries('a', tree.path2id('a'))]
+        output = [e.name for e in tree.iter_child_entries('a')]
         self.assertEqual({'b', 'd'}, set(output))
 
     def test_does_not_exist(self):

--- a/breezy/tests/per_workingtree/test_add_reference.py
+++ b/breezy/tests/per_workingtree/test_add_reference.py
@@ -50,23 +50,17 @@ class TestBasisInventory(TestCaseWithWorkingTree):
     def test_add_reference(self):
         tree, sub_tree = self.make_nested_trees()
         sub_tree_root_id = sub_tree.get_root_id()
-        tree.lock_write()
-        try:
+        with tree.lock_write():
             if tree.supports_setting_file_ids():
                 self.assertEqual(tree.path2id('sub-tree'), sub_tree_root_id)
             self.assertEqual(tree.kind('sub-tree'), 'tree-reference')
             tree.commit('commit reference')
             basis = tree.basis_tree()
-            basis.lock_read()
-            try:
-                sub_tree = tree.get_nested_tree('sub-tree', sub_tree_root_id)
+            with basis.lock_read():
+                sub_tree = tree.get_nested_tree('sub-tree')
                 self.assertEqual(
                         sub_tree.last_revision(),
-                        tree.get_reference_revision('sub-tree', sub_tree_root_id))
-            finally:
-                basis.unlock()
-        finally:
-            tree.unlock()
+                        tree.get_reference_revision('sub-tree'))
 
     def test_add_reference_same_root(self):
         tree = self.make_branch_and_tree('tree')
@@ -108,11 +102,6 @@ class TestBasisInventory(TestCaseWithWorkingTree):
     def test_get_nested_tree(self):
         tree, sub_tree = self.make_nested_trees()
         sub_tree_root_id = sub_tree.get_root_id()
-        tree.lock_read()
-        try:
-            sub_tree2 = tree.get_nested_tree('sub-tree', sub_tree_root_id)
-            self.assertEqual(sub_tree.basedir, sub_tree2.basedir)
+        with tree.lock_read():
             sub_tree2 = tree.get_nested_tree('sub-tree')
             self.assertEqual(sub_tree.basedir, sub_tree2.basedir)
-        finally:
-            tree.unlock()

--- a/breezy/tests/per_workingtree/test_get_file_mtime.py
+++ b/breezy/tests/per_workingtree/test_get_file_mtime.py
@@ -38,57 +38,37 @@ class TestGetFileMTime(TestCaseWithWorkingTree):
 
     def test_get_file_mtime(self):
         tree = self.make_basic_tree()
-        one_id = tree.path2id('one')
 
         st = os.lstat('tree/one')
-        tree.lock_read()
-        try:
+        with tree.lock_read():
             mtime_file_id = tree.get_file_mtime('one')
             self.assertIsInstance(mtime_file_id, (float, int))
             self.assertAlmostEqual(st.st_mtime, mtime_file_id)
-            mtime_path = tree.get_file_mtime('one', file_id=one_id)
-            self.assertAlmostEqual(mtime_file_id, mtime_path)
-        finally:
-            tree.unlock()
 
     def test_after_commit(self):
         """Committing shouldn't change the mtime."""
         tree = self.make_basic_tree()
-        one_id = tree.path2id('one')
 
         st = os.lstat('tree/one')
         tree.commit('one')
 
-        tree.lock_read()
-        try:
+        with tree.lock_read():
             mtime = tree.get_file_mtime('one')
             self.assertAlmostEqual(st.st_mtime, mtime)
-
-            mtime = tree.get_file_mtime('one', one_id)
-            self.assertAlmostEqual(st.st_mtime, mtime)
-        finally:
-            tree.unlock()
 
     def test_get_renamed_time(self):
         """We should handle renamed files."""
         tree = self.make_basic_tree()
-        one_id = tree.path2id('one')
 
         tree.rename_one('one', 'two')
         st = os.lstat('tree/two')
 
-        tree.lock_read()
-        try:
+        with tree.lock_read():
             mtime = tree.get_file_mtime('two')
             self.assertAlmostEqual(st.st_mtime, mtime)
-            mtime = tree.get_file_mtime('two', one_id)
-            self.assertAlmostEqual(st.st_mtime, mtime)
-        finally:
-            tree.unlock()
 
     def test_get_renamed_in_subdir_time(self):
         tree = self.make_branch_and_tree('tree')
-        one_id = tree.path2id('one')
         self.build_tree(['tree/d/', 'tree/d/a'])
         tree.add(['d', 'd/a'])
         a_id = tree.path2id('d/a')
@@ -97,18 +77,12 @@ class TestGetFileMTime(TestCaseWithWorkingTree):
         tree.rename_one('d', 'e')
 
         st = os.lstat('tree/e/a')
-        tree.lock_read()
-        try:
+        with tree.lock_read():
             mtime = tree.get_file_mtime('e/a')
             self.assertAlmostEqual(st.st_mtime, mtime)
-            mtime = tree.get_file_mtime('e/a', a_id)
-            self.assertAlmostEqual(st.st_mtime, mtime)
-        finally:
-            tree.unlock()
 
     def test_missing(self):
         tree = self.make_basic_tree()
-        one_id = tree.path2id('one')
 
         os.remove('tree/one')
         with tree.lock_read():

--- a/breezy/tests/per_workingtree/test_mkdir.py
+++ b/breezy/tests/per_workingtree/test_mkdir.py
@@ -29,7 +29,7 @@ class TestMkdir(TestCaseWithWorkingTree):
         t.lock_write()
         self.addCleanup(t.unlock)
         file_id = t.mkdir('path')
-        self.assertEqual('directory', t.kind('path', file_id))
+        self.assertEqual('directory', t.kind('path'))
 
     def test_mkdir_with_id(self):
         t = self.make_branch_and_tree('t1')
@@ -42,4 +42,4 @@ class TestMkdir(TestCaseWithWorkingTree):
         else:
             file_id = t.mkdir('path', b'my-id')
             self.assertEqual(b'my-id', file_id)
-            self.assertEqual('directory', t.kind('path', file_id))
+            self.assertEqual('directory', t.kind('path'))

--- a/breezy/tests/test_bundle.py
+++ b/breezy/tests/test_bundle.py
@@ -174,7 +174,7 @@ class MockTree(object):
         return self.inventory.get_entry_by_path(path).revision
 
     def get_file_size(self, path):
-        return self.inventory.get_entry_by_path(file_id).text_size
+        return self.inventory.get_entry_by_path(path).text_size
 
     def get_file_sha1(self, path, file_id=None):
         return self.inventory.get_entry_by_path(path).text_sha1

--- a/breezy/tests/test_bundle.py
+++ b/breezy/tests/test_bundle.py
@@ -92,7 +92,7 @@ class MockTree(object):
     def all_versioned_paths(self):
         return set(self.paths.values())
 
-    def is_executable(self, path, file_id):
+    def is_executable(self, path):
         # Not all the files are executable.
         return False
 
@@ -112,10 +112,8 @@ class MockTree(object):
         for path, file_id in self.ids.items():
             yield path, self[file_id]
 
-    def kind(self, path, file_id=None):
-        if file_id is None:
-            file_id = self.path2id(path)
-        if file_id in self.contents:
+    def kind(self, path):
+        if path in self.contents:
             kind = 'file'
         else:
             kind = 'directory'
@@ -152,7 +150,7 @@ class MockTree(object):
         if not isinstance(file_id, bytes):
             raise TypeError(file_id)
         self.add_dir(file_id, path)
-        self.contents[file_id] = contents
+        self.contents[path] = contents
 
     def path2id(self, path):
         return self.ids.get(path)
@@ -163,37 +161,29 @@ class MockTree(object):
     def has_id(self, file_id):
         return self.id2path(file_id) is not None
 
-    def get_file(self, path, file_id=None):
-        if file_id is None:
-            file_id = self.path2id(path)
+    def get_file(self, path):
         result = BytesIO()
         try:
-            result.write(self.contents[file_id])
+            result.write(self.contents[path])
         except KeyError:
             raise errors.NoSuchFile(path)
         result.seek(0, 0)
         return result
 
-    def get_file_revision(self, path, file_id=None):
-        if file_id is None:
-            file_id = self.path2id(path)
-        return self.inventory[file_id].revision
+    def get_file_revision(self, path):
+        return self.inventory.get_entry_by_path(path).revision
 
-    def get_file_size(self, path, file_id=None):
-        if file_id is None:
-            file_id = self.path2id(path)
-        return self.inventory[file_id].text_size
+    def get_file_size(self, path):
+        return self.inventory.get_entry_by_path(file_id).text_size
 
     def get_file_sha1(self, path, file_id=None):
-        if file_id is None:
-            file_id = self.path2id(path)
-        return self.inventory[file_id].text_sha1
+        return self.inventory.get_entry_by_path(path).text_sha1
 
-    def contents_stats(self, path, file_id):
-        if file_id not in self.contents:
+    def contents_stats(self, path):
+        if path not in self.contents:
             return None, None
-        text_sha1 = osutils.sha_file(self.get_file(path, file_id))
-        return text_sha1, len(self.contents[file_id])
+        text_sha1 = osutils.sha_file(self.get_file(path))
+        return text_sha1, len(self.contents[path])
 
 
 class BTreeTester(tests.TestCase):
@@ -605,9 +595,9 @@ class BundleTester(object):
 
         for path, status, kind, fileid, entry in base_files:
             # Check that the meta information is the same
-            self.assertEqual(base_tree.get_file_size(path, fileid),
+            self.assertEqual(base_tree.get_file_size(path),
                     to_tree.get_file_size(to_tree.id2path(fileid)))
-            self.assertEqual(base_tree.get_file_sha1(path, fileid),
+            self.assertEqual(base_tree.get_file_sha1(path),
                     to_tree.get_file_sha1(to_tree.id2path(fileid)))
             # Check that the contents are the same
             # This is pretty expensive
@@ -988,7 +978,7 @@ class BundleTester(object):
         self.tree1.commit('message', rev_id=b'revid1')
         bundle = self.get_valid_bundle(b'null:', b'revid1')
         tree = self.get_bundle_tree(bundle, b'revid1')
-        root_revision = tree.get_file_revision(u'', tree.get_root_id())
+        root_revision = tree.get_file_revision(u'')
         self.assertEqual(b'revid1', root_revision)
 
     def test_install_revisions(self):

--- a/breezy/tests/test_bundle.py
+++ b/breezy/tests/test_bundle.py
@@ -63,11 +63,8 @@ def get_text(vf, key):
 
 def get_inventory_text(repo, revision_id):
     """Get the fulltext for the inventory at revision id"""
-    repo.lock_read()
-    try:
+    with repo.lock_read():
         return get_text(repo.inventories, (revision_id,))
-    finally:
-        repo.unlock()
 
 
 class MockTree(object):
@@ -102,6 +99,9 @@ class MockTree(object):
         else:
             return self.make_entry(file_id, self.paths[file_id])
 
+    def get_entry_by_path(self, path):
+        return self[self.path2id(path)]
+
     def parent_id(self, file_id):
         parent_dir = os.path.dirname(self.paths[file_id])
         if parent_dir == "":
@@ -125,9 +125,9 @@ class MockTree(object):
         if not isinstance(file_id, bytes):
             raise TypeError(file_id)
         name = os.path.basename(path)
-        kind = self.kind(path, file_id)
+        kind = self.kind(path)
         parent_id = self.parent_id(file_id)
-        text_sha_1, text_size = self.contents_stats(path, file_id)
+        text_sha_1, text_size = self.contents_stats(path)
         if kind == 'directory':
             ie = InventoryDirectory(file_id, name, parent_id)
         elif kind == 'file':

--- a/breezy/tests/test_bzrdir.py
+++ b/breezy/tests/test_bzrdir.py
@@ -847,9 +847,7 @@ class ChrootedTests(TestCaseWithTransport):
         tree2.lock_read()
         self.addCleanup(tree2.unlock)
         self.assertPathExists('tree2/subtree/file')
-        self.assertEqual(
-                'tree-reference',
-                tree2.kind('subtree', 'subtree-root'))
+        self.assertEqual('tree-reference', tree2.kind('subtree'))
 
     def test_cloning_metadir(self):
         """Ensure that cloning metadir is suitable"""

--- a/breezy/tests/test_extract.py
+++ b/breezy/tests/test_extract.py
@@ -28,7 +28,7 @@ class TestExtract(TestCaseWithTransport):
         wt = self.make_branch_and_tree('a', format='rich-root-pack')
         wt.add(['b', 'b/c', 'd'], [b'b-id', b'c-id', b'd-id'])
         wt.commit('added files')
-        b_wt = wt.extract('b', b'b-id')
+        b_wt = wt.extract('b')
         self.assertEqual(b'b-id', b_wt.get_root_id())
         self.assertEqual(b'c-id', b_wt.path2id('c'))
         self.assertEqual('c', b_wt.id2path(b'c-id'))
@@ -43,7 +43,7 @@ class TestExtract(TestCaseWithTransport):
         wt = a_branch.create_checkout('a', lightweight=True)
         wt.add(['b', 'b/c', 'b/c/d'], [b'b-id', b'c-id', b'd-id'])
         wt.commit('added files')
-        return wt.extract('b', b'b-id')
+        return wt.extract('b')
 
     def test_extract_in_checkout(self):
         a_branch = self.make_branch('branch', format='rich-root-pack')
@@ -59,7 +59,7 @@ class TestExtract(TestCaseWithTransport):
         wt.add(['b', 'b/c', 'b/c/d', 'b/c/d/e/'], [b'b-id', b'c-id', b'd-id',
                 b'e-id'])
         wt.commit('added files')
-        b_wt = wt.extract('b/c/d', b'd-id')
+        b_wt = wt.extract('b/c/d')
         b_branch = branch.Branch.open('branch/b/c/d')
         b_branch_ref = branch.Branch.open('a/b/c/d')
         self.assertEqual(b_branch.base, b_branch_ref.base)

--- a/breezy/tests/test_foreign.py
+++ b/breezy/tests/test_foreign.py
@@ -194,8 +194,8 @@ class InterToDummyVcsBranch(branch.GenericInterBranch):
             for revid in todo:
                 rev = self.source.repository.get_revision(revid)
                 tree = self.source.repository.revision_tree(revid)
-                def get_file_with_stat(path, file_id=None):
-                    return (tree.get_file(path, file_id), None)
+                def get_file_with_stat(path):
+                    return (tree.get_file(path), None)
                 tree.get_file_with_stat = get_file_with_stat
                 new_revid = self.target.mapping.revision_id_foreign_to_bzr(
                     (b'%d' % rev.timestamp, str(rev.timezone).encode('ascii'),

--- a/breezy/tests/test_merge.py
+++ b/breezy/tests/test_merge.py
@@ -524,7 +524,7 @@ class TestMerge(TestCaseWithTransport):
         source.add('foo', b'foo-id')
         source.commit('Add foo')
         target = source.controldir.sprout('target').open_workingtree()
-        subtree = target.extract('foo', b'foo-id')
+        subtree = target.extract('foo')
         subtree.commit('Delete root')
         self.build_tree(['source/bar'])
         source.add('bar', b'bar-id')

--- a/breezy/tests/test_repository.py
+++ b/breezy/tests/test_repository.py
@@ -505,28 +505,21 @@ class TestRepositoryFormatKnit3(TestCaseWithTransport):
         tree = self.make_branch_and_tree('.', format)
         tree.commit("Dull commit", rev_id=b"dull")
         revision_tree = tree.branch.repository.revision_tree(b'dull')
-        revision_tree.lock_read()
-        try:
+        with revision_tree.lock_read():
             self.assertRaises(errors.NoSuchFile, revision_tree.get_file_lines,
-                u'', revision_tree.get_root_id())
-        finally:
-            revision_tree.unlock()
+                u'')
         format = bzrdir.BzrDirMetaFormat1()
         format.repository_format = knitrepo.RepositoryFormatKnit3()
         upgrade.Convert('.', format)
         tree = workingtree.WorkingTree.open('.')
         revision_tree = tree.branch.repository.revision_tree(b'dull')
-        revision_tree.lock_read()
-        try:
-            revision_tree.get_file_lines(u'', revision_tree.get_root_id())
-        finally:
-            revision_tree.unlock()
+        with revision_tree.lock_read():
+            revision_tree.get_file_lines(u'')
         tree.commit("Another dull commit", rev_id=b'dull2')
         revision_tree = tree.branch.repository.revision_tree(b'dull2')
         revision_tree.lock_read()
         self.addCleanup(revision_tree.unlock)
-        self.assertEqual(b'dull',
-                revision_tree.get_file_revision(u'', revision_tree.get_root_id()))
+        self.assertEqual(b'dull', revision_tree.get_file_revision(u''))
 
     def test_supports_external_lookups(self):
         format = bzrdir.BzrDirMetaFormat1()

--- a/breezy/tests/test_revisiontree.py
+++ b/breezy/tests/test_revisiontree.py
@@ -62,8 +62,7 @@ class TestTreeWithCommits(TestCaseWithTransport):
         self.assertIs(None, null_tree.get_root_id())
 
     def test_get_file_revision_root(self):
-        self.assertEqual(self.rev_id,
-            self.rev_tree.get_file_revision(u'', self.rev_tree.get_root_id()))
+        self.assertEqual(self.rev_id, self.rev_tree.get_file_revision(u''))
 
     def test_get_file_revision(self):
         self.build_tree_contents([('a', b'initial')])

--- a/breezy/tests/test_shelf.py
+++ b/breezy/tests/test_shelf.py
@@ -279,7 +279,7 @@ class TestPrepareShelf(tests.TestCaseWithTransport):
         ptree = creator.shelf_transform.get_preview_tree()
         self.assertEqual(
                 link_target,
-                ptree.get_symlink_target(ptree.id2path(b'foo-id'), b'foo-id'))
+                ptree.get_symlink_target(ptree.id2path(b'foo-id')))
 
     def test_shelve_symlink_creation(self):
         self._test_shelve_symlink_creation('foo', 'bar')

--- a/breezy/tests/test_subsume.py
+++ b/breezy/tests/test_subsume.py
@@ -90,7 +90,7 @@ class TestWorkingTree(tests.TestCaseWithTransport):
         self.assertEqual(b'subtree-1',
                          basis_tree.get_file_revision('subtree/file2'))
         self.assertEqual(b'combined-1',
-                         basis_tree.get_file_revision('subtree', sub_root_id))
+                         basis_tree.get_file_revision('subtree'))
 
     def test_subsume_failure(self):
         base_tree, sub_tree = self.make_trees()

--- a/breezy/tests/test_transform.py
+++ b/breezy/tests/test_transform.py
@@ -2274,9 +2274,8 @@ class TestBuildTree(tests.TestCaseWithTransport):
         entry2_state = entry2[1][0]
         # Now, make sure that we don't have to re-read the content. The
         # packed_stat should match exactly.
-        self.assertEqual(entry1_sha, target.get_file_sha1('file1', b'file1-id'))
-        self.assertEqual(entry2_sha,
-                         target.get_file_sha1('dir/file2', b'file2-id'))
+        self.assertEqual(entry1_sha, target.get_file_sha1('file1'))
+        self.assertEqual(entry2_sha, target.get_file_sha1('dir/file2'))
         self.assertEqual(entry1_state, entry1[1][0])
         self.assertEqual(entry2_state, entry2[1][0])
 
@@ -2851,7 +2850,7 @@ class TestTransformPreview(tests.TestCaseWithTransport):
         preview.adjust_path('renamed', preview.root, file_trans_id)
         preview_tree = preview.get_preview_tree()
         preview_mtime = preview_tree.get_file_mtime('renamed')
-        work_mtime = work_tree.get_file_mtime('file', b'file-id')
+        work_mtime = work_tree.get_file_mtime('file')
 
     def test_get_file_size(self):
         work_tree = self.make_branch_and_tree('tree')

--- a/breezy/tests/test_transform.py
+++ b/breezy/tests/test_transform.py
@@ -190,7 +190,7 @@ class TestTreeTransform(tests.TestCaseWithTransport):
             orig(*args)
         self.wt._observed_sha1 = _observed_sha1
         trans.apply()
-        self.assertEqual([(None, 'file1', trans._observed_sha1s[trans_id])],
+        self.assertEqual([('file1', trans._observed_sha1s[trans_id])],
                          calls)
 
     def test_create_file_caches_sha1(self):
@@ -2352,7 +2352,7 @@ class TestCommitTransform(tests.TestCaseWithTransport):
         rev = tt.commit(branch, 'message')
         tree = branch.basis_tree()
         self.assertEqual('file', tree.id2path(b'file-id'))
-        self.assertEqual(b'contents', tree.get_file_text('file', b'file-id'))
+        self.assertEqual(b'contents', tree.get_file_text('file'))
         self.assertEqual('dir', tree.id2path(b'dir-id'))
         if SymlinkFeature.available():
             self.assertEqual('dir/symlink', tree.id2path(b'symlink-id'))
@@ -2743,7 +2743,7 @@ class TestTransformPreview(tests.TestCaseWithTransport):
         preview.new_file('file2', preview.root, [b'content B\n'], b'file2-id')
         preview_tree = preview.get_preview_tree()
         self.assertEqual(preview_tree.kind('file2'), 'file')
-        with preview_tree.get_file('file2', b'file2-id') as f:
+        with preview_tree.get_file('file2') as f:
             self.assertEqual(f.read(), b'content B\n')
 
     def test_diff_preview_tree(self):
@@ -2839,7 +2839,7 @@ class TestTransformPreview(tests.TestCaseWithTransport):
         limbo_path = preview._limbo_name(file_trans_id)
         preview_tree = preview.get_preview_tree()
         self.assertEqual(os.stat(limbo_path).st_mtime,
-                         preview_tree.get_file_mtime('file', b'file-id'))
+                         preview_tree.get_file_mtime('file'))
 
     def test_get_file_mtime_renamed(self):
         work_tree = self.make_branch_and_tree('tree')
@@ -2850,7 +2850,7 @@ class TestTransformPreview(tests.TestCaseWithTransport):
         file_trans_id = preview.trans_id_tree_path('file')
         preview.adjust_path('renamed', preview.root, file_trans_id)
         preview_tree = preview.get_preview_tree()
-        preview_mtime = preview_tree.get_file_mtime('renamed', b'file-id')
+        preview_mtime = preview_tree.get_file_mtime('renamed')
         work_mtime = work_tree.get_file_mtime('file', b'file-id')
 
     def test_get_file_size(self):
@@ -3305,7 +3305,6 @@ class TestTransformPreview(tests.TestCaseWithTransport):
         self.addCleanup(preview.finalize)
         preview.new_file('foo', preview.root, [b'bar'], b'baz-id')
         preview_tree = preview.get_preview_tree()
-        self.assertEqual(False, preview_tree.is_executable('tree/foo', b'baz-id'))
         self.assertEqual(False, preview_tree.is_executable('tree/foo'))
 
     def test_commit_preview_tree(self):

--- a/breezy/tests/test_workingtree_4.py
+++ b/breezy/tests/test_workingtree_4.py
@@ -717,7 +717,7 @@ class TestWorkingTreeFormat4(TestCaseWithTransport):
         tree = self.get_tree_with_cachable_file_foo()
         expected_sha1 = osutils.sha_file_by_name('foo')
         statvalue = os.lstat("foo")
-        tree._observed_sha1(b"foo-id", "foo", (expected_sha1, statvalue))
+        tree._observed_sha1("foo", (expected_sha1, statvalue))
         entry = tree._get_entry(path="foo")
         entry_state = entry[1][0]
         self.assertEqual(expected_sha1, entry_state[1])
@@ -739,7 +739,7 @@ class TestWorkingTreeFormat4(TestCaseWithTransport):
         with tree.lock_read():
             current_sha1 = tree._get_entry(path="foo")[1][0][1]
         with tree.lock_write():
-            tree._observed_sha1(b"foo-id", "foo",
+            tree._observed_sha1("foo",
                 (osutils.sha_file_by_name('foo'), os.lstat("foo")))
             # Must not have changed
             self.assertEqual(current_sha1,

--- a/breezy/workingtree.py
+++ b/breezy/workingtree.py
@@ -1289,7 +1289,7 @@ class WorkingTree(mutabletree.MutableTree,
             for conflict in self.conflicts():
                 path = self.id2path(conflict.file_id)
                 if (conflict.typestring != 'text conflict' or
-                    self.kind(path, conflict.file_id) != 'file'):
+                    self.kind(path) != 'file'):
                     un_resolved.append(conflict)
                     continue
                 with open(self.abspath(path), 'rb') as my_file:


### PR DESCRIPTION
Remove file ids from many of the public Tree functions.
