### PR TITLE
Fix 'bzr grep' in git working trees.

### DIFF
--- a/breezy/git/tests/test_blackbox.py
+++ b/breezy/git/tests/test_blackbox.py
@@ -326,3 +326,14 @@ class ShallowTests(ExternalBase):
                  'gitr'])
         self.assertEqual(error, '')
         self.assertEqual(output, 'VERSION_INFO \n')
+
+
+class GrepTests(ExternalBase):
+
+    def test_simple_grep(self):
+        tree = self.make_branch_and_tree('.', format='git')
+        self.build_tree_contents([('a', 'text for a\n')])
+        tree.add(['a'])
+        output, error = self.run_bzr('grep text')
+        self.assertEqual(output, 'a:text for a\n')
+        self.assertEqual(error, '')

--- a/breezy/git/tree.py
+++ b/breezy/git/tree.py
@@ -389,7 +389,7 @@ class GitRevisionTree(revisiontree.RevisionTree):
     def list_files(self, include_root=False, from_dir=None, recursive=True):
         if self.tree is None:
             return
-        if from_dir is None:
+        if from_dir is None or from_dir == '.':
             from_dir = u""
         (store, mode, hexsha) = self._lookup_path(from_dir)
         if mode is None: # Root

--- a/breezy/git/workingtree.py
+++ b/breezy/git/workingtree.py
@@ -746,7 +746,7 @@ class GitWorkingTree(MutableGitIndexTree,workingtree.WorkingTree):
             return self._is_executable_from_path_and_stat_from_basis(path, stat_result)
 
     def list_files(self, include_root=False, from_dir=None, recursive=True):
-        if from_dir is None:
+        if from_dir is None or from_dir == '.':
             from_dir = u""
         dir_ids = {}
         fk_entries = {'directory': tree.TreeDirectory,

--- a/breezy/tests/per_tree/test_list_files.py
+++ b/breezy/tests/per_tree/test_list_files.py
@@ -29,13 +29,23 @@ class TestListFiles(TestCaseWithTree):
                     ('b', 'V', 'directory', tree.path2id('b')),
                     ('b/c', 'V', 'file', tree.path2id('b/c')),
                    ]
-        tree.lock_read()
-        try:
+        with tree.lock_read():
             actual = [(path, status, kind, file_id)
                       for path, status, kind, file_id, ie in
                           tree.list_files(include_root=True)]
-        finally:
-            tree.unlock()
+        self.assertEqual(expected, actual)
+
+    def test_list_files_from_dir_root(self):
+        work_tree = self.make_branch_and_tree('wt')
+        tree = self.get_tree_no_parents_abc_content(work_tree)
+        expected = [('a', 'V', 'file', tree.path2id('a')),
+                    ('b', 'V', 'directory', tree.path2id('b')),
+                    ('b/c', 'V', 'file', tree.path2id('b/c')),
+                   ]
+        with tree.lock_read():
+            actual = [(path, status, kind, file_id)
+                      for path, status, kind, file_id, ie in
+                          tree.list_files(from_dir='.')]
         self.assertEqual(expected, actual)
 
     def test_list_files_no_root(self):
@@ -45,13 +55,10 @@ class TestListFiles(TestCaseWithTree):
                     ('b', 'V', 'directory', tree.path2id('b')),
                     ('b/c', 'V', 'file', tree.path2id('b/c')),
                    ]
-        tree.lock_read()
-        try:
+        with tree.lock_read():
             actual = [(path, status, kind, file_id)
                       for path, status, kind, file_id, ie in
                           tree.list_files()]
-        finally:
-            tree.unlock()
         self.assertEqual(expected, actual)
 
     def test_list_files_with_root_no_recurse(self):
@@ -74,27 +81,20 @@ class TestListFiles(TestCaseWithTree):
         expected = [('a', 'V', 'file', tree.path2id('a'))]
         expected.append(
             ('b', 'V', 'directory', tree.path2id('b')))
-        tree.lock_read()
-        try:
+        with tree.lock_read():
             actual = [(path, status, kind, file_id)
                 for path, status, kind, file_id, ie in
                     tree.list_files(recursive=False)]
-        finally:
-            tree.unlock()
         self.assertEqual(expected, actual)
 
     def test_list_files_from_dir(self):
         work_tree = self.make_branch_and_tree('wt')
         tree = self.get_tree_no_parents_abc_content(work_tree)
-        expected = [('c', 'V', 'file', tree.path2id('b/c')),
-                   ]
-        tree.lock_read()
-        try:
+        expected = [('c', 'V', 'file', tree.path2id('b/c'))]
+        with tree.lock_read():
             actual = [(path, status, kind, file_id)
                       for path, status, kind, file_id, ie in
                           tree.list_files(from_dir=u'b')]
-        finally:
-            tree.unlock()
         self.assertEqual(expected, actual)
 
     def test_list_files_from_dir_no_recurse(self):

--- a/breezy/transform.py
+++ b/breezy/transform.py
@@ -2214,6 +2214,8 @@ class _PreviewTree(inventorytree.InventoryTree):
         """See WorkingTree.list_files."""
         # XXX This should behave like WorkingTree.list_files, but is really
         # more like RevisionTree.list_files.
+        if from_dir == '.':
+            from_dir = None
         if recursive:
             prefix = None
             if from_dir:


### PR DESCRIPTION
Fix 'bzr grep' in git working trees.
