### PR TITLE
Don't report .git files as unknown.

### DIFF
--- a/breezy/git/workingtree.py
+++ b/breezy/git/workingtree.py
@@ -539,7 +539,7 @@ class GitWorkingTree(MutableGitIndexTree, workingtree.WorkingTree):
                 if self.mapping.is_special_file(name):
                     continue
                 if self.controldir.is_control_filename(
-                    name.decode(osutils._fs_enc)):
+                        name.decode(osutils._fs_enc, 'replace')):
                     continue
                 yp = os.path.join(dir_relpath, name)
                 try:

--- a/breezy/git/workingtree.py
+++ b/breezy/git/workingtree.py
@@ -536,13 +536,17 @@ class GitWorkingTree(MutableGitIndexTree, workingtree.WorkingTree):
                     if not self._has_dir(relpath):
                         dirnames.remove(name)
             for name in filenames:
-                if not self.mapping.is_special_file(name):
-                    yp = os.path.join(dir_relpath, name)
-                    try:
-                        yield yp.decode(osutils._fs_enc)
-                    except UnicodeDecodeError:
-                        raise errors.BadFilenameEncoding(
-                            yp, osutils._fs_enc)
+                if self.mapping.is_special_file(name):
+                    continue
+                if self.controldir.is_control_filename(
+                    name.decode(osutils._fs_enc)):
+                    continue
+                yp = os.path.join(dir_relpath, name)
+                try:
+                    yield yp.decode(osutils._fs_enc)
+                except UnicodeDecodeError:
+                    raise errors.BadFilenameEncoding(
+                        yp, osutils._fs_enc)
 
     def extras(self):
         """Yield all unversioned files in this WorkingTree.

--- a/doc/en/release-notes/brz-3.0.txt
+++ b/doc/en/release-notes/brz-3.0.txt
@@ -224,6 +224,9 @@ Bug Fixes
   needed for backwards compatibility with Bazaar.
   (Jelmer Vernooĳ, #1803845)
 
+* Don't report .git files as unknown files.
+  (Jelmer Vernooĳ, Debian Bug #921240)
+
 Documentation
 *************
 


### PR DESCRIPTION
Don't report .git files as unknown.

.git files are used for referencing git locations, and commonly used in submodules.