### PR TITLE
Move .generate_ids to breezy.bzr.

### DIFF
--- a/breezy/bzr/generate_ids.py
+++ b/breezy/bzr/generate_ids.py
@@ -18,7 +18,7 @@
 
 from __future__ import absolute_import
 
-from .lazy_import import lazy_import
+from ..lazy_import import lazy_import
 lazy_import(globals(), """
 import time
 
@@ -28,10 +28,10 @@ from breezy import (
     )
 """)
 
-from . import (
+from .. import (
     lazy_regex,
     )
-from .sixish import text_type
+from ..sixish import text_type
 
 # the regex removes any weird characters; we don't escape them
 # but rather just pull them out

--- a/breezy/bzr/inventory.py
+++ b/breezy/bzr/inventory.py
@@ -38,18 +38,16 @@ except ImportError:  # python < 3.7
 from ..lazy_import import lazy_import
 lazy_import(globals(), """
 
-from breezy import (
-    generate_ids,
-    osutils,
-    )
 from breezy.bzr import (
     chk_map,
+    generate_ids,
     )
 """)
 
 from .. import (
     errors,
     lazy_regex,
+    osutils,
     trace,
     )
 from ..sixish import (

--- a/breezy/bzr/vf_repository.py
+++ b/breezy/bzr/vf_repository.py
@@ -39,6 +39,7 @@ from breezy import (
 from breezy.bzr import (
     fetch as _mod_fetch,
     check,
+    generate_ids,
     inventory_delta,
     inventorytree,
     versionedfile,
@@ -229,6 +230,10 @@ class VersionedFileCommitBuilder(CommitBuilder):
             basis_id, self._basis_delta, self._new_revision_id,
             self.parents)
         return self._new_revision_id
+
+    def _gen_revision_id(self):
+        """Return new revision-id."""
+        return generate_ids.gen_revision_id(self._committer, self._timestamp)
 
     def _require_root_change(self, tree):
         """Enforce an appropriate root object change.

--- a/breezy/bzr/workingtree_4.py
+++ b/breezy/bzr/workingtree_4.py
@@ -39,7 +39,6 @@ from breezy import (
     debug,
     errors,
     filters as _mod_filters,
-    generate_ids,
     osutils,
     revision as _mod_revision,
     revisiontree,
@@ -49,6 +48,7 @@ from breezy import (
     )
 from breezy.bzr import (
     dirstate,
+    generate_ids,
     )
 """)
 

--- a/breezy/plugins/fastimport/bzr_commit_handler.py
+++ b/breezy/plugins/fastimport/bzr_commit_handler.py
@@ -25,6 +25,7 @@ from ... import (
     revision,
     )
 from ...bzr import (
+    generate_ids,
     inventory,
     serializer,
     )

--- a/breezy/repository.py
+++ b/breezy/repository.py
@@ -24,7 +24,6 @@ from breezy import (
     config,
     controldir,
     debug,
-    generate_ids,
     graph,
     osutils,
     revision as _mod_revision,
@@ -182,10 +181,6 @@ class CommitBuilder(object):
             repository.get_inventory.
         """
         raise NotImplementedError(self.finish_inventory)
-
-    def _gen_revision_id(self):
-        """Return new revision-id."""
-        return generate_ids.gen_revision_id(self._committer, self._timestamp)
 
     def _generate_revision_if_needed(self, revision_id):
         """Create a revision id if None was supplied.

--- a/breezy/tests/test_generate_ids.py
+++ b/breezy/tests/test_generate_ids.py
@@ -17,8 +17,10 @@
 """Tests for breezy/generate_ids.py"""
 
 from .. import (
-    generate_ids,
     tests,
+    )
+from ..bzr import (
+    generate_ids,
     )
 
 

--- a/breezy/tests/test_merge_core.py
+++ b/breezy/tests/test_merge_core.py
@@ -21,7 +21,6 @@ import breezy
 from .. import (
     controldir,
     errors,
-    generate_ids,
     merge_directive,
     osutils,
     )
@@ -35,6 +34,9 @@ from ..merge import (
     Diff3Merger,
     WeaveMerger,
     Merger,
+    )
+from ..bzr import (
+    generate_ids,
     )
 from ..osutils import getcwd, pathjoin
 from ..transform import TreeTransform

--- a/breezy/tests/test_transform.py
+++ b/breezy/tests/test_transform.py
@@ -24,7 +24,6 @@ from .. import (
     bencode,
     errors,
     filters,
-    generate_ids,
     osutils,
     revision as _mod_revision,
     rules,
@@ -32,6 +31,9 @@ from .. import (
     trace,
     transform,
     urlutils,
+    )
+from ..bzr import (
+    generate_ids,
     )
 from ..conflicts import (
     DeletingParent,

--- a/breezy/upstream_import.py
+++ b/breezy/upstream_import.py
@@ -28,7 +28,8 @@ import stat
 import tarfile
 import zipfile
 
-from . import generate_ids, urlutils
+from . import urlutils
+from .bzr import generate_ids
 from .controldir import ControlDir, is_control_filename
 from .errors import (BzrError, NoSuchFile, BzrCommandError, NotBranchError)
 from .osutils import (pathjoin, isdir, file_iterator, basename,

--- a/breezy/workingtree.py
+++ b/breezy/workingtree.py
@@ -46,12 +46,14 @@ from breezy import (
     controldir,
     errors,
     filters as _mod_filters,
-    generate_ids,
     merge,
     revision as _mod_revision,
     transform,
     transport,
     views,
+    )
+from breezy.bzr import (
+    generate_ids,
     )
 """)
 


### PR DESCRIPTION
Move .generate_ids to breezy.bzr.

This functionality is bzr-specific.