### PR TITLE
Allow unknown HG fields in Git commit metadata when accessing native Git repositories.

### DIFF
--- a/breezy/git/mapping.py
+++ b/breezy/git/mapping.py
@@ -37,6 +37,7 @@ from ..foreign import (
     )
 from ..revision import (
     NULL_REVISION,
+    Revision,
     )
 from ..sixish import (
     PY3,
@@ -377,6 +378,17 @@ class BzrGitMapping(foreign.VcsMapping):
         """
         return deserialize_fileid_map(blob.data)
 
+    def get_revision_id(self, commit):
+        if commit.encoding:
+            encoding = commit.encoding.decode('ascii')
+        else:
+            encoding = 'utf-8'
+        message, metadata = self._decode_commit_message(
+            None, commit.message, encoding)
+        if metadata.revision_id:
+            return metadata.revision_id
+        return self.revision_id_foreign_to_bzr(commit.id)
+
     def import_commit(self, commit, lookup_parent_revid):
         """Convert a git commit to a bzr revision.
 
@@ -499,6 +511,8 @@ class BzrGitMappingExperimental(BzrGitMappingv1):
     BZR_DUMMY_FILE = '.bzrdummy'
 
     def _decode_commit_message(self, rev, message, encoding):
+        if rev is None:
+            rev = Revision()
         message = self._extract_hg_metadata(rev, message)
         message = self._extract_git_svn_metadata(rev, message)
         message, metadata = self._extract_bzr_metadata(rev, message)

--- a/breezy/git/repository.py
+++ b/breezy/git/repository.py
@@ -348,9 +348,9 @@ class LocalGitRepository(GitRepository):
             o = self._git.object_store[sha]
             if not isinstance(o, Commit):
                 continue
-            rev, roundtrip_revid, verifiers = mapping.import_commit(
-                o, mapping.revision_id_foreign_to_bzr)
-            yield o.id, rev.revision_id, roundtrip_revid
+            revid = mapping.revision_id_foreign_to_bzr(o)
+            roundtrip_revid = mapping.get_revision_id(o)
+            yield o.id, revid, (roundtrip_revid if revid != roundtrip_revid else None)
 
     def all_revision_ids(self):
         ret = set()
@@ -454,13 +454,9 @@ class LocalGitRepository(GitRepository):
         commit = self._git.object_store.peel_sha(foreign_revid)
         if not isinstance(commit, Commit):
             raise NotCommitError(commit.id)
-        rev, roundtrip_revid, verifiers = mapping.import_commit(
-            commit, mapping.revision_id_foreign_to_bzr)
+        revid = mapping.get_revision_id(commit)
         # FIXME: check testament before doing this?
-        if roundtrip_revid:
-            return roundtrip_revid
-        else:
-            return rev.revision_id
+        return revid
 
     def has_signature_for_revision_id(self, revision_id):
         """Check whether a GPG signature is present for this revision.

--- a/breezy/git/tests/test_blackbox.py
+++ b/breezy/git/tests/test_blackbox.py
@@ -308,6 +308,7 @@ class ShallowTests(ExternalBase):
         self.repo.stage("foo")
         self.repo.do_commit(
             b"message", committer=b"Somebody <user@example.com>",
+            author=b"Somebody <user@example.com>",
             commit_timestamp=1526330165, commit_timezone=0,
             author_timestamp=1526330165, author_timezone=0,
             merge_heads=[b'aa' * 20])

--- a/breezy/git/tests/test_mapping.py
+++ b/breezy/git/tests/test_mapping.py
@@ -235,6 +235,9 @@ class TestImportCommit(tests.TestCase):
         self.assertRaises(
             UnknownMercurialCommitExtra,
             mapping.import_commit, c, mapping.revision_id_foreign_to_bzr)
+        self.assertEqual(
+            mapping.revision_id_foreign_to_bzr(c.id),
+            mapping.get_revision_id(c))
 
 
 class RoundtripRevisionsFromBazaar(tests.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ META_INFO = {
         # Technically, Breezy works without these two dependencies too. But there's
         # no way to enable them by default and let users opt out.
         'fastimport>=0.9.8',
-        'dulwich>=0.19.1',
+        'dulwich>=0.19.11',
         ],
     'extras_require': {
         'fastimport': [],


### PR DESCRIPTION
Allow unknown HG fields in Git commit metadata when accessing native Git repositories.

This will still prevent roundtripping into bzr and back, e.g. fetch. But there
is no reason why git-native operations should not work.