### PR TITLE
Drop dependency on non-longer-existant grep plugin.

### DIFF
--- a/breezy/git/tests/test_blackbox.py
+++ b/breezy/git/tests/test_blackbox.py
@@ -386,7 +386,6 @@ class SwitchTests(ExternalBase):
 class GrepTests(ExternalBase):
 
     def test_simple_grep(self):
-        self.requireFeature(PluginLoadedFeature('grep'))
         tree = self.make_branch_and_tree('.', format='git')
         self.build_tree_contents([('a', 'text for a\n')])
         tree.add(['a'])


### PR DESCRIPTION
Drop dependency on non-longer-existant grep plugin.