### PR TITLE
Bump minimum dulwich version to 0.19.11.

### DIFF
--- a/breezy/git/__init__.py
+++ b/breezy/git/__init__.py
@@ -27,7 +27,7 @@ from __future__ import absolute_import
 import os
 import sys
 
-dulwich_minimum_version = (0, 19, 7)
+dulwich_minimum_version = (0, 19, 11)
 
 from .. import (  # noqa: F401
     __version__ as breezy_version,


### PR DESCRIPTION
Bump minimum dulwich version to 0.19.11.

This is necessary since older versions of Dulwich have an incompatible ObjectStore API.