### PR TITLE
Return consist errors from Branch.get_revid and Repository.get_revid_for_revno.

### DIFF
--- a/breezy/bzr/branch.py
+++ b/breezy/bzr/branch.py
@@ -50,7 +50,6 @@ from ..decorators import (
     only_raises,
     )
 from ..lock import _RelockDebugMixin, LogicalLockResult
-from ..repository import RevnoOutOfBounds
 from ..sixish import (
     BytesIO,
     text_type,
@@ -650,7 +649,7 @@ class BzrBranch8(BzrBranch):
         with self.lock_read():
             last_revno, last_revision_id = self.last_revision_info()
             if revno <= 0 or revno > last_revno:
-                raise RevnoOutOfBounds(revno, (0, last_revno))
+                raise errors.RevnoOutOfBounds(revno, (0, last_revno))
 
             if history is not None:
                 return history[revno - 1]

--- a/breezy/bzr/branch.py
+++ b/breezy/bzr/branch.py
@@ -50,6 +50,7 @@ from ..decorators import (
     only_raises,
     )
 from ..lock import _RelockDebugMixin, LogicalLockResult
+from ..repository import RevnoOutOfBounds
 from ..sixish import (
     BytesIO,
     text_type,
@@ -649,7 +650,7 @@ class BzrBranch8(BzrBranch):
         with self.lock_read():
             last_revno, last_revision_id = self.last_revision_info()
             if revno <= 0 or revno > last_revno:
-                raise errors.NoSuchRevision(self, revno)
+                raise RevnoOutOfBounds(revno, (0, last_revno))
 
             if history is not None:
                 return history[revno - 1]

--- a/breezy/bzr/smart/repository.py
+++ b/breezy/bzr/smart/repository.py
@@ -54,7 +54,6 @@ from .request import (
     SuccessfulSmartServerResponse,
     )
 from ...repository import (
-    RevnoOutOfBounds,
     _strip_NULL_ghosts,
     network_format_registry,
     )
@@ -339,7 +338,7 @@ class SmartServerRepositoryGetRevIdForRevno(SmartServerRepositoryReadLocked):
                     'non-initial revision: ' + err.revision)
             return FailedSmartServerResponse(
                 (b'nosuchrevision', err.revision))
-        except RevnoOutOfBounds as e:
+        except errors.RevnoOutOfBounds as e:
             return FailedSmartServerResponse(
                 (b'revno-outofbounds', e.revno, e.minimum, e.maximum))
         if found_flag:

--- a/breezy/errors.py
+++ b/breezy/errors.py
@@ -2452,3 +2452,13 @@ class ChangesAlreadyStored(BzrCommandError):
 
     _fmt = ('Cannot store uncommitted changes because this branch already'
             ' stores uncommitted changes.')
+
+
+class RevnoOutOfBounds(InternalBzrError):
+
+    _fmt = ("The requested revision number %(revno)d is outside of the "
+            "expected boundaries (%(minimum)d <= %(maximum)d).")
+
+    def __init__(self, revno, bounds):
+        InternalBzrError.__init__(
+            self, revno=revno, minimum=bounds[0], maximum=bounds[1])

--- a/breezy/git/revspec.py
+++ b/breezy/git/revspec.py
@@ -107,7 +107,8 @@ class RevisionSpec_git(RevisionSpec):
     def _match_on(self, branch, revs):
         loc = self.spec.find(':')
         git_sha1 = self.spec[loc + 1:].encode("utf-8")
-        if len(git_sha1) > 40 or not valid_git_sha1(git_sha1):
+        if (len(git_sha1) > 40 or len(git_sha1) < 4 or
+                not valid_git_sha1(git_sha1)):
             raise InvalidRevisionSpec(self.user_spec, branch)
         from . import (
             lazy_check_versions,

--- a/breezy/repository.py
+++ b/breezy/repository.py
@@ -66,16 +66,6 @@ class CannotSetRevisionId(errors.BzrError):
     _fmt = "Repository format does not support setting revision ids."
 
 
-class RevnoOutOfBounds(errors.InternalBzrError):
-
-    _fmt = ("The requested revision number %(revno)d is outside of the "
-            "expected boundaries (%(minimum)d <= %(maximum)d).")
-
-    def __init__(self, revno, bounds):
-        errors.InternalBzrError.__init__(
-            self, revno=revno, minimum=bounds[0], maximum=bounds[1])
-
-
 class CommitBuilder(object):
     """Provides an interface to build up a commit.
 
@@ -933,7 +923,7 @@ class Repository(controldir.ControlComponent, _RelockDebugMixin):
         partial_history = [known_revid]
         distance_from_known = known_revno - revno
         if distance_from_known < 0:
-            raise RevnoOutOfBounds(revno, (0, known_revno))
+            raise errors.RevnoOutOfBounds(revno, (0, known_revno))
         try:
             _iter_for_revno(
                 self, partial_history, stop_index=distance_from_known)

--- a/breezy/revisionspec.py
+++ b/breezy/revisionspec.py
@@ -422,7 +422,7 @@ class RevisionSpec_revno(RevisionSpec):
                     revno = last_revno + revno + 1
             try:
                 revision_id = branch.get_rev_id(revno)
-            except errors.NoSuchRevision:
+            except (errors.NoSuchRevision, errors.RevnoOutOfBounds):
                 raise errors.InvalidRevisionSpec(self.user_spec, branch)
         return branch, revno, revision_id
 

--- a/breezy/tests/per_branch/__init__.py
+++ b/breezy/tests/per_branch/__init__.py
@@ -155,6 +155,7 @@ def load_tests(loader, standard_tests, pattern):
         'create_clone',
         'commit',
         'dotted_revno_to_revision_id',
+        'get_rev_id',
         'get_revision_id_to_revno_map',
         'hooks',
         'http',

--- a/breezy/tests/per_branch/test_get_rev_id.py
+++ b/breezy/tests/per_branch/test_get_rev_id.py
@@ -16,7 +16,7 @@
 
 """Tests for Branch.get_rev_id."""
 
-from breezy.errors import NoSuchRevision
+from breezy.repository import RevnoOutOfBounds
 from breezy.revision import NULL_REVISION
 from breezy.tests import TestCaseWithTransport
 
@@ -27,8 +27,8 @@ class TestGetRevid(TestCaseWithTransport):
         # on an empty branch we want (0, NULL_REVISION)
         branch = self.make_branch('branch')
         self.assertEqual(NULL_REVISION, branch.get_rev_id(0))
-        self.assertRaises(NoSuchRevision, branch.get_rev_id, 1)
-        self.assertRaises(NoSuchRevision, branch.get_rev_id, -1)
+        self.assertRaises(RevnoOutOfBounds, branch.get_rev_id, 1)
+        self.assertRaises(RevnoOutOfBounds, branch.get_rev_id, -1)
 
     def test_non_empty_branch(self):
         # after the second commit we want (2, 'second-revid')
@@ -37,4 +37,4 @@ class TestGetRevid(TestCaseWithTransport):
         revid2 = tree.commit('2st post', allow_pointless=True)
         self.assertEqual(revid2, tree.branch.get_rev_id(2))
         self.assertEqual(revid1, tree.branch.get_rev_id(1))
-        self.assertRaises(NoSuchRevision, tree.branch.get_rev_id, 3)
+        self.assertRaises(RevnoOutOfBounds, tree.branch.get_rev_id, 3)

--- a/breezy/tests/per_branch/test_get_rev_id.py
+++ b/breezy/tests/per_branch/test_get_rev_id.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2007, 2009-2012, 2016 Canonical Ltd
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+"""Tests for Branch.get_rev_id."""
+
+from breezy.errors import NoSuchRevision
+from breezy.revision import NULL_REVISION
+from breezy.tests import TestCaseWithTransport
+
+
+class TestGetRevid(TestCaseWithTransport):
+
+    def test_empty_branch(self):
+        # on an empty branch we want (0, NULL_REVISION)
+        branch = self.make_branch('branch')
+        self.assertEqual(NULL_REVISION, branch.get_rev_id(0))
+        self.assertRaises(NoSuchRevision, branch.get_rev_id, 1)
+        self.assertRaises(NoSuchRevision, branch.get_rev_id, -1)
+
+    def test_non_empty_branch(self):
+        # after the second commit we want (2, 'second-revid')
+        tree = self.make_branch_and_tree('branch')
+        revid1 = tree.commit('1st post')
+        revid2 = tree.commit('2st post', allow_pointless=True)
+        self.assertEqual(revid2, tree.branch.get_rev_id(2))
+        self.assertEqual(revid1, tree.branch.get_rev_id(1))
+        self.assertRaises(NoSuchRevision, tree.branch.get_rev_id, 3)

--- a/breezy/tests/per_repository/__init__.py
+++ b/breezy/tests/per_repository/__init__.py
@@ -118,6 +118,7 @@ def load_tests(loader, standard_tests, pattern):
         'test_fetch',
         'test_file_graph',
         'test_get_parent_map',
+        'test_get_rev_id_for_revno',
         'test_has_same_location',
         'test_has_revisions',
         'test_locking',

--- a/breezy/tests/per_repository/test_get_rev_id_for_revno.py
+++ b/breezy/tests/per_repository/test_get_rev_id_for_revno.py
@@ -1,0 +1,61 @@
+# Copyright (C) 2009 Canonical Ltd
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+"""Tests for get_rev_id_for_revno."""
+
+from breezy import errors
+from breezy.tests.per_repository_reference import (
+    TestCaseWithExternalReferenceRepository,
+    )
+
+
+class TestGetRevIdForRevno(TestCaseWithExternalReferenceRepository):
+
+    def setUp(self):
+        super(TestGetRevIdForRevno, self).setUp()
+        self.tree = self.make_branch_and_tree('base')
+        self.revid1 = self.tree.commit('one')
+        self.revid2 = self.tree.commit('two')
+        self.revid3 = self.tree.commit('three')
+
+    def test_success(self):
+        repo = self.tree.branch.repository
+        repo.lock_read()
+        self.addCleanup(repo.unlock)
+        self.assertEqual(
+            (True, self.revid1),
+            repo.get_rev_id_for_revno(1, (3, self.revid3)))
+        self.assertEqual(
+            (True, self.revid2),
+            repo.get_rev_id_for_revno(2, (3, self.revid3)))
+
+    def test_unknown_revision(self):
+        tree2 = self.make_branch_and_tree('other')
+        unknown_revid = tree2.commit('other')
+        repo = self.tree.branch.repository
+        repo.lock_read()
+        self.addCleanup(repo.unlock)
+        self.assertRaises(
+            errors.RevisionNotPresent,
+            repo.get_rev_id_for_revno, 1, (3, unknown_revid))
+
+    def test_known_pair_is_after(self):
+        repo = self.tree.branch.repository
+        repo.lock_read()
+        self.addCleanup(repo.unlock)
+        self.assertRaises(
+            ValueError,
+            repo.get_rev_id_for_revno, 3, (2, self.revid2))

--- a/breezy/tests/per_repository/test_get_rev_id_for_revno.py
+++ b/breezy/tests/per_repository/test_get_rev_id_for_revno.py
@@ -17,6 +17,7 @@
 """Tests for get_rev_id_for_revno."""
 
 from breezy import errors
+from breezy.repository import RevnoOutOfBounds
 from breezy.tests.per_repository_reference import (
     TestCaseWithExternalReferenceRepository,
     )
@@ -49,7 +50,7 @@ class TestGetRevIdForRevno(TestCaseWithExternalReferenceRepository):
         repo.lock_read()
         self.addCleanup(repo.unlock)
         self.assertRaises(
-            errors.RevisionNotPresent,
+            errors.NoSuchRevision,
             repo.get_rev_id_for_revno, 1, (3, unknown_revid))
 
     def test_known_pair_is_after(self):
@@ -57,5 +58,5 @@ class TestGetRevIdForRevno(TestCaseWithExternalReferenceRepository):
         repo.lock_read()
         self.addCleanup(repo.unlock)
         self.assertRaises(
-            ValueError,
+            RevnoOutOfBounds,
             repo.get_rev_id_for_revno, 3, (2, self.revid2))

--- a/breezy/tests/test_remote.py
+++ b/breezy/tests/test_remote.py
@@ -3918,6 +3918,12 @@ class TestErrorTranslationSuccess(TestErrorTranslationBase):
         expected_error = errors.UnknownErrorFromSmartServer(err)
         self.assertEqual(expected_error, translated_error)
 
+    def test_RevnoOutOfBounds(self):
+        translated_error = self.translateTuple(
+            ((b'revno-outofbounds', 5, 0, 3)), path=b'path')
+        expected_error = repository.RevnoOutOfBounds(5, (0, 3))
+        self.assertEqual(expected_error, translated_error)
+
 
 class TestErrorTranslationRobustness(TestErrorTranslationBase):
     """Unit tests for breezy.bzr.remote._translate_error's robustness.

--- a/doc/en/release-notes/brz-3.0.txt
+++ b/doc/en/release-notes/brz-3.0.txt
@@ -230,6 +230,10 @@ Bug Fixes
 * Don't report .git files as unknown files.
   (Jelmer Vernooĳ, Debian Bug #921240)
 
+* Return consist errors from ``Branch.get_revid`` and
+  ``Repository.get_revid_for_revno`` when the revision
+  number is invalid. (Jelmer Vernooĳ, #701953)
+
 Documentation
 *************
 


### PR DESCRIPTION
Return consist errors from Branch.get_revid and Repository.get_revid_for_revno.

Also, add a bunch of tests that were previously lacking for
Repository.get_rev_id_for_revno and Branch.get_rev_id.