### PR TITLE
Raise better error when subsegments lack =.

### DIFF
--- a/breezy/tests/test_urlutils.py
+++ b/breezy/tests/test_urlutils.py
@@ -599,6 +599,8 @@ class TestUrlToPath(TestCase):
         self.assertEqual(("foo/base,key1=val1/other/elements",
                           {"key2": "val2"}), split_segment_parameters(
             "foo/base,key1=val1/other/elements,key2=val2"))
+        self.assertRaises(urlutils.InvalidURL, split_segment_parameters,
+            "foo/base,key1")
         # TODO: Check full URLs as well as relative references
 
     def test_win32_strip_local_trailing_slash(self):

--- a/breezy/urlutils.py
+++ b/breezy/urlutils.py
@@ -561,7 +561,10 @@ def split_segment_parameters(url):
     (base_url, subsegments) = split_segment_parameters_raw(url)
     parameters = {}
     for subsegment in subsegments:
-        (key, value) = subsegment.split("=", 1)
+        try:
+            (key, value) = subsegment.split("=", 1)
+        except ValueError:
+            raise InvalidURL(url, "missing = in subsegment")
         if not isinstance(key, str):
             raise TypeError(key)
         if not isinstance(value, str):

--- a/doc/en/release-notes/brz-3.0.txt
+++ b/doc/en/release-notes/brz-3.0.txt
@@ -230,6 +230,9 @@ Bug Fixes
 * Don't report .git files as unknown files.
   (Jelmer Vernooĳ, Debian Bug #921240)
 
+* Raise better error when path subsegments lack =.
+  (Jelmer Vernooĳ, #891483)
+
 Documentation
 *************
 


### PR DESCRIPTION
Raise better error when subsegments lack =.