### PR TITLE
Print proper error when running `brz cat-revision` on Git repositories.

### DIFF
--- a/breezy/builtins.py
+++ b/breezy/builtins.py
@@ -454,11 +454,11 @@ class cmd_cat_revision(Command):
 
         b = controldir.ControlDir.open_containing_tree_or_branch(directory)[1]
 
-        revisions = b.repository.revisions
+        revisions = getattr(b.repository, "revisions", None)
         if revisions is None:
             raise errors.BzrCommandError(
                 gettext('Repository %r does not support '
-                        'access to raw revision texts'))
+                        'access to raw revision texts') % b.repository)
 
         with b.repository.lock_read():
             # TODO: jam 20060112 should cat-revision always output utf-8?

--- a/breezy/git/tests/test_blackbox.py
+++ b/breezy/git/tests/test_blackbox.py
@@ -78,6 +78,15 @@ class TestGitBlackBox(ExternalBase):
         self.assertEqual(output, '')
         self.assertFileEqual("foo\n", ".gitignore")
 
+    def test_cat_revision(self):
+        self.simple_commit()
+        output, error = self.run_bzr(['cat-revision', '-r-1'], retcode=3)
+        self.assertContainsRe(
+            error,
+            'brz: ERROR: Repository .* does not support access to raw '
+            'revision texts')
+        self.assertEqual(output, '')
+
     def test_branch(self):
         os.mkdir("gitbranch")
         GitRepo.init(os.path.join(self.test_dir, "gitbranch"))


### PR DESCRIPTION
Print proper error when running `brz cat-revision` on Git repositories.