### PR TITLE
Use setuptools in setup.py.

### DIFF
--- a/doc/en/release-notes/brz-3.0.txt
+++ b/doc/en/release-notes/brz-3.0.txt
@@ -85,6 +85,9 @@ External Compatibility Breaks
    longer performed, since there are no longer
    any automated imports. (Jelmer Vernooĳ)
 
+ * ``setuptools`` is now required to build and install Breezy.
+   (Jelmer Vernooĳ)
+
 New Features
 ************
 

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ BREEZY['packages'] = get_breezy_packages()
 
 
 from distutils import log
-from distutils.core import setup
+from setuptools import setup
 from distutils.version import LooseVersion
 from distutils.command.install_scripts import install_scripts
 from distutils.command.install_data import install_data

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,14 @@ if sys.version_info < (2, 7):
     sys.stderr.write("[ERROR] Not a supported Python version. Need 2.7+\n")
     sys.exit(1)
 
+
+try:
+    import setuptools
+except ImportError:
+    sys.stderr.write("[ERROR] Please install setuptools\n")
+    sys.exit(1)
+
+
 # NOTE: The directory containing setup.py, whether run by 'python setup.py' or
 # './setup.py' or the equivalent with another path, should always be at the
 # start of the path, so this should find the right one...
@@ -118,7 +126,6 @@ def get_breezy_packages():
 BREEZY['packages'] = get_breezy_packages()
 
 
-from distutils import log
 from setuptools import setup
 from distutils.version import LooseVersion
 from distutils.command.install_scripts import install_scripts


### PR DESCRIPTION
Use setuptools in setup.py.

This allows various new options for setup() to be used, such as
install_requires. setuptools is already common enough that this should be fine.