### PR TITLE
Use time.perf_counter, which is replacing time.clock.

### DIFF
--- a/breezy/bzr/smart/medium.py
+++ b/breezy/bzr/smart/medium.py
@@ -433,13 +433,13 @@ class SmartServerSocketStreamMedium(SmartServerStreamMedium):
         self.finished = True
 
     def _write_out(self, bytes):
-        tstart = osutils.timer_func()
+        tstart = osutils.perf_counter()
         osutils.send_all(self.socket, bytes, self._report_activity)
         if 'hpss' in debug.debug_flags:
             thread_id = _thread.get_ident()
             trace.mutter('%12s: [%s] %d bytes to the socket in %.3fs'
                          % ('wrote', thread_id, len(bytes),
-                            osutils.timer_func() - tstart))
+                            osutils.perf_counter() - tstart))
 
 
 class SmartServerPipeStreamMedium(SmartServerStreamMedium):

--- a/breezy/bzr/smart/protocol.py
+++ b/breezy/bzr/smart/protocol.py
@@ -639,7 +639,7 @@ class SmartClientRequestProtocolOne(SmartProtocolBase, Requester,
             mutter('hpss call:   %s', repr(args)[1:-1])
             if getattr(self._request._medium, 'base', None) is not None:
                 mutter('             (to %s)', self._request._medium.base)
-            self._request_start_time = osutils.timer_func()
+            self._request_start_time = osutils.perf_counter()
         self._write_args(args)
         self._request.finished_writing()
         self._last_verb = args[0]
@@ -655,7 +655,7 @@ class SmartClientRequestProtocolOne(SmartProtocolBase, Requester,
                 mutter('                  (to %s)',
                        self._request._medium._path)
             mutter('              %d bytes', len(body))
-            self._request_start_time = osutils.timer_func()
+            self._request_start_time = osutils.perf_counter()
             if 'hpssdetail' in debug.debug_flags:
                 mutter('hpss body content: %s', body)
         self._write_args(args)
@@ -675,7 +675,7 @@ class SmartClientRequestProtocolOne(SmartProtocolBase, Requester,
             if getattr(self._request._medium, '_path', None) is not None:
                 mutter('                  (to %s)',
                        self._request._medium._path)
-            self._request_start_time = osutils.timer_func()
+            self._request_start_time = osutils.perf_counter()
         self._write_args(args)
         readv_bytes = self._serialise_offsets(body)
         bytes = self._encode_bulk_data(readv_bytes)
@@ -707,7 +707,7 @@ class SmartClientRequestProtocolOne(SmartProtocolBase, Requester,
         if 'hpss' in debug.debug_flags:
             if self._request_start_time is not None:
                 mutter('   result:   %6.3fs  %s',
-                       osutils.timer_func() - self._request_start_time,
+                       osutils.perf_counter() - self._request_start_time,
                        repr(result)[1:-1])
                 self._request_start_time = None
             else:
@@ -1173,9 +1173,9 @@ class ProtocolThreeResponder(_ProtocolThreeEncoder):
 
     def _trace(self, action, message, extra_bytes=None, include_time=False):
         if self._response_start_time is None:
-            self._response_start_time = osutils.timer_func()
+            self._response_start_time = osutils.perf_counter()
         if include_time:
-            t = '%5.3fs ' % (time.clock() - self._response_start_time)
+            t = '%5.3fs ' % (osutils.perf_counter() - self._response_start_time)
         else:
             t = ''
         if extra_bytes is None:
@@ -1318,7 +1318,7 @@ class ProtocolThreeRequester(_ProtocolThreeEncoder, Requester):
             base = getattr(self._medium_request._medium, 'base', None)
             if base is not None:
                 mutter('             (to %s)', base)
-            self._request_start_time = osutils.timer_func()
+            self._request_start_time = osutils.perf_counter()
         self._write_protocol_version()
         self._write_headers(self._headers)
         self._write_structure(args)
@@ -1336,7 +1336,7 @@ class ProtocolThreeRequester(_ProtocolThreeEncoder, Requester):
             if path is not None:
                 mutter('                  (to %s)', path)
             mutter('              %d bytes', len(body))
-            self._request_start_time = osutils.timer_func()
+            self._request_start_time = osutils.perf_counter()
         self._write_protocol_version()
         self._write_headers(self._headers)
         self._write_structure(args)
@@ -1355,7 +1355,7 @@ class ProtocolThreeRequester(_ProtocolThreeEncoder, Requester):
             path = getattr(self._medium_request._medium, '_path', None)
             if path is not None:
                 mutter('                  (to %s)', path)
-            self._request_start_time = osutils.timer_func()
+            self._request_start_time = osutils.perf_counter()
         self._write_protocol_version()
         self._write_headers(self._headers)
         self._write_structure(args)
@@ -1372,7 +1372,7 @@ class ProtocolThreeRequester(_ProtocolThreeEncoder, Requester):
             path = getattr(self._medium_request._medium, '_path', None)
             if path is not None:
                 mutter('                  (to %s)', path)
-            self._request_start_time = osutils.timer_func()
+            self._request_start_time = osutils.perf_counter()
         self.body_stream_started = False
         self._write_protocol_version()
         self._write_headers(self._headers)

--- a/breezy/bzr/smart/request.py
+++ b/breezy/bzr/smart/request.py
@@ -309,7 +309,7 @@ class SmartServerRequestHandler(object):
         self.finished_reading = False
         self._command = None
         if 'hpss' in debug.debug_flags:
-            self._request_start_time = osutils.timer_func()
+            self._request_start_time = osutils.perf_counter()
             self._thread_id = get_ident()
 
     def _trace(self, action, message, extra_bytes=None, include_time=False):
@@ -318,7 +318,7 @@ class SmartServerRequestHandler(object):
         # that just putting it in a helper doesn't help a lot. And some state
         # is taken from the instance.
         if include_time:
-            t = '%5.3fs ' % (osutils.timer_func() - self._request_start_time)
+            t = '%5.3fs ' % (osutils.perf_counter() - self._request_start_time)
         else:
             t = ''
         if extra_bytes is None:

--- a/breezy/graph.py
+++ b/breezy/graph.py
@@ -612,11 +612,11 @@ class Graph(object):
         # In the common case, we don't need to spider out far here, so
         # avoid doing extra work.
         if step_all_unique:
-            tstart = time.clock()
+            tstart = osutils.perf_counter()
             nodes = all_unique_searcher.step()
             common_to_all_unique_nodes.update(nodes)
             if 'graph' in debug.debug_flags:
-                tdelta = time.clock() - tstart
+                tdelta = osutils.perf_counter() - tstart
                 trace.mutter('all_unique_searcher step() took %.3fs'
                              'for %d nodes (%d total), iteration: %s',
                              tdelta, len(nodes), len(all_unique_searcher.seen),

--- a/breezy/osutils.py
+++ b/breezy/osutils.py
@@ -70,15 +70,6 @@ from . import (
     )
 
 
-# Cross platform wall-clock time functionality with decent resolution.
-# On Linux ``time.clock`` returns only CPU time. On Windows, ``time.time()``
-# only has a resolution of ~15ms. Note that ``time.clock()`` is not
-# synchronized with ``time.time()``, this is only meant to be used to find
-# delta times by subtracting from another call to this function.
-timer_func = time.time
-if sys.platform == 'win32':
-    timer_func = time.clock
-
 # On win32, O_BINARY is used to indicate the file should
 # be opened in binary mode, rather than text mode.
 # On other platforms, O_BINARY doesn't exist, because
@@ -2609,3 +2600,9 @@ def is_environment_error(evalue):
     if sys.platform == "win32" and win32utils._is_pywintypes_error(evalue):
         return True
     return False
+
+
+if PY3:
+    perf_counter = time.perf_counter
+else:
+    perf_counter = time.clock

--- a/tools/time_graph.py
+++ b/tools/time_graph.py
@@ -8,6 +8,7 @@ from breezy import (
     branch,
     commands,
     graph,
+    osutils,
     ui,
     trace,
     _known_graph_py,
@@ -24,7 +25,7 @@ opts, args = p.parse_args(sys.argv[1:])
 trace.enable_default_logging()
 ui.ui_factory = text.TextUIFactory()
 
-begin = time.clock()
+begin = osutils.perf_counter()
 if len(args) >= 1:
     b = branch.Branch.open(args[0])
 else:
@@ -33,7 +34,7 @@ with b.lock_read():
     g = b.repository.get_graph()
     parent_map = dict(p for p in g.iter_ancestry([b.last_revision()])
                       if p[1] is not None)
-end = time.clock()
+end = osutils.perf_counter()
 
 print('Found %d nodes, loaded in %.3fs' % (len(parent_map), end - begin))
 
@@ -73,13 +74,13 @@ def combi_graph(graph_klass, comb):
     graph._counters[1] = 0
     graph._counters[2] = 0
 
-    begin = time.clock()
+    begin = osutils.perf_counter()
     g = graph_klass(parent_map)
     if opts.lsprof is not None:
         heads = commands.apply_lsprofiled(opts.lsprof, all_heads_comp, g, comb)
     else:
         heads = all_heads_comp(g, comb)
-    end = time.clock()
+    end = osutils.perf_counter()
     return dict(elapsed=(end - begin), graph=g, heads=heads)
 
 def report(name, g):


### PR DESCRIPTION
Use time.perf_counter, which is replacing time.clock.

time.clock is going away in Python 3.8.

Also, rename osutils.timer_func to perf_counter for consistency.