### PR TITLE
Use standard patch functions in "bzr git-apply".

### DIFF
--- a/breezy/builtins.py
+++ b/breezy/builtins.py
@@ -7018,6 +7018,31 @@ class cmd_grep(Command):
             grep.versioned_grep(opts)
 
 
+class cmd_patch(Command):
+    """Apply a named patch to the current tree.
+
+    """
+    takes_args = ['filename?']
+    takes_options = [Option('strip', type=int, short_name='p',
+                            help=("Strip the smallest prefix containing num "
+                                  "leading slashes  from filenames")),
+                     Option('silent', help='Suppress chatter.')]
+
+    def run(self, filename=None, strip=None, silent=False):
+        from .patch import patch_tree
+        from bzrlib.workingtree import WorkingTree
+        wt = WorkingTree.open_containing('.')[0]
+        if strip is None:
+            strip = 1
+        my_file = None
+        if filename is None:
+            my_file = sys.stdin
+        else:
+            my_file = open(filename)
+        patches = [my_file.read()]
+        return patch_tree(wt, patches, strip, quiet=is_quiet(), out=self.outf)
+
+
 def _register_lazy_builtins():
     # register lazy builtins from other modules; called at startup and should
     # be only called once.

--- a/breezy/git/commands.py
+++ b/breezy/git/commands.py
@@ -265,19 +265,12 @@ class cmd_git_apply(Command):
         :param f: Patch file to read.
         :param signoff: Add Signed-Off-By flag.
         """
-        from ..i18n import gettext
-        from ..errors import BzrCommandError
         from dulwich.patch import git_am_patch_split
-        import subprocess
+        from breezy.patch import patch_tree
         (c, diff, version) = git_am_patch_split(f)
         # FIXME: Cope with git-specific bits in patch
         # FIXME: Add new files to working tree
-        p = subprocess.Popen(["patch", "-p1"], stdin=subprocess.PIPE,
-                             cwd=wt.basedir)
-        p.communicate(diff)
-        exitcode = p.wait()
-        if exitcode != 0:
-            raise BzrCommandError(gettext("error running patch"))
+        patch_tree(wt, [diff], strip=1, out=self.outf)
         message = c.message.decode('utf-8')
         if signoff:
             signed_off_by = wt.branch.get_config().username()

--- a/breezy/patch.py
+++ b/breezy/patch.py
@@ -119,19 +119,14 @@ def diff3(out_file, mine_path, older_path, yours_path):
     return status
 
 
-def patch_multi(tree, location, strip, quiet=False):
-    """Apply a patch to a branch, using patch(1).  URLs may be used."""
-    my_file = None
-    if location is None:
-        my_file = sys.stdin
-    else:
-        my_file = open_from_url(location)
-    patches = [my_file.read()]
-    return run_patch(tree.basedir, patches, strip, quiet=quiet)
+def patch_tree(tree, patches, strip=0, reverse=False, dry_run=False, quiet=False,
+               out=None):
+    return run_patch(tree.basedir, patches, strip, reverse, dry_run, quiet,
+                     out=out)
 
 
 def run_patch(directory, patches, strip=0, reverse=False, dry_run=False,
-              quiet=False, _patch_cmd='patch', target_file=None):
+              quiet=False, _patch_cmd='patch', target_file=None, out=None):
     args = [_patch_cmd, '-d', directory, '-s', '-p%d' % strip, '-f']
     if quiet:
         args.append('--quiet')
@@ -166,7 +161,10 @@ def run_patch(directory, patches, strip=0, reverse=False, dry_run=False,
 
     result = process.wait()
     if not dry_run:
-        sys.stdout.write(process.stdout.read())
+        if out is not None:
+            out.write(process.stdout.read())
+        else:
+            process.stdout.read()
     if result != 0:
         raise PatchFailed()
 

--- a/breezy/tests/blackbox/__init__.py
+++ b/breezy/tests/blackbox/__init__.py
@@ -92,6 +92,7 @@ def load_tests(loader, basic_tests, pattern):
         'test_non_ascii',
         'test_outside_wt',
         'test_pack',
+        'test_patch',
         'test_ping',
         'test_plugins',
         'test_pull',

--- a/breezy/tests/blackbox/test_patch.py
+++ b/breezy/tests/blackbox/test_patch.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2019 Breezy Developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+
+from breezy.tests import TestCaseWithTransport
+
+
+class TestPatch(TestCaseWithTransport):
+
+    def test_patch(self):
+        self.run_bzr('init')
+        with open('myfile', 'w') as f:
+            f.write('hello')
+        self.run_bzr('add')
+        self.run_bzr('commit -m hello')
+        with open('myfile', 'w') as f:
+            f.write('goodbye')
+        with open('mypatch', 'w') as f:
+            f.write(self.run_bzr('diff -p1', retcode=1)[0])
+        self.run_bzr('revert')
+        self.assertFileEqual('hello', 'myfile')
+        self.run_bzr('patch -p1 --silent mypatch')
+        self.assertFileEqual('goodbye', 'myfile')

--- a/breezy/tests/test_patch.py
+++ b/breezy/tests/test_patch.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2006 Canonical Ltd
+# Copyright (C) 2008 Aaron Bentley <aaron@aaronbentley.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,7 +16,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 from breezy.errors import BinaryFile
-from breezy.patch import diff3
+from breezy.patch import diff3, PatchInvokeError, run_patch
 from breezy.tests import TestCaseInTempDir
 
 
@@ -29,3 +30,10 @@ class TestPatch(TestCaseInTempDir):
         with open('base', 'wb') as f:
             f.write(b'\x00')
         self.assertRaises(BinaryFile, diff3, 'unused', 'this', 'other', 'base')
+
+
+class TestPatch(TestCaseInTempDir):
+
+    def test_missing_patch(self):
+        self.assertRaises(PatchInvokeError, run_patch, '.', [],
+                          _patch_cmd='/unlikely/to/exist')

--- a/doc/en/release-notes/brz-3.1.txt
+++ b/doc/en/release-notes/brz-3.1.txt
@@ -21,6 +21,9 @@ New Features
 
 .. New commands, options, etc that users may wish to try out.
 
+ * The 'patch' command is now bundled with brz.
+   Imported from bzrtools by Aaron Bentley. (Jelmer Vernooĳ)
+
 Improvements
 ************
 


### PR DESCRIPTION
Use standard patch functions in "bzr git-apply".

This stops patch output from leaking to stderr during test runs.