### PR TITLE
Cope with utf-8 invalid characters in commit messages when scanning for revision ids.

### DIFF
--- a/breezy/git/mapping.py
+++ b/breezy/git/mapping.py
@@ -383,10 +383,14 @@ class BzrGitMapping(foreign.VcsMapping):
             encoding = commit.encoding.decode('ascii')
         else:
             encoding = 'utf-8'
-        message, metadata = self._decode_commit_message(
-            None, commit.message, encoding)
-        if metadata.revision_id:
-            return metadata.revision_id
+        try:
+            message, metadata = self._decode_commit_message(
+                None, commit.message, encoding)
+        except UnicodeDecodeError:
+            pass
+        else:
+            if metadata.revision_id:
+                return metadata.revision_id
         return self.revision_id_foreign_to_bzr(commit.id)
 
     def import_commit(self, commit, lookup_parent_revid):

--- a/breezy/git/tests/test_mapping.py
+++ b/breezy/git/tests/test_mapping.py
@@ -239,6 +239,21 @@ class TestImportCommit(tests.TestCase):
             mapping.revision_id_foreign_to_bzr(c.id),
             mapping.get_revision_id(c))
 
+    def test_invalid_utf8(self):
+        c = Commit()
+        c.tree = b"cc9462f7f8263ef5adfbeff2fb936bb36b504cba"
+        c.message = b"Some message \xc1"
+        c.committer = b"Committer"
+        c.commit_time = 4
+        c.author_time = 5
+        c.commit_timezone = 60 * 5
+        c.author_timezone = 60 * 3
+        c.author = b"Author"
+        mapping = BzrGitMappingv1()
+        self.assertEqual(
+            mapping.revision_id_foreign_to_bzr(c.id),
+            mapping.get_revision_id(c))
+
 
 class RoundtripRevisionsFromBazaar(tests.TestCase):
 


### PR DESCRIPTION
Cope with utf-8 invalid characters in commit messages when scanning for revision ids.