### PR TITLE
Fix a nasty corner case merging changes into a tree with changed symlinks

### DIFF
--- a/breezy/git/object_store.py
+++ b/breezy/git/object_store.py
@@ -361,22 +361,11 @@ def _tree_to_objects(tree, parent_trees, idmap, unusual_modes,
         if tree.kind(path) != 'directory':
             continue
 
-        obj = Tree()
-        for value in tree.iter_child_entries(path):
-            if value.name in BANNED_FILENAMES:
-                trace.warning('not exporting %s with banned filename %s',
-                              value.kind, value.name)
-                continue
-            child_path = osutils.pathjoin(path, value.name)
-            try:
-                mode = unusual_modes[child_path]
-            except KeyError:
-                mode = entry_mode(value)
-            hexsha = ie_to_hexsha(child_path, value)
-            if hexsha is not None:
-                obj.add(value.name.encode("utf-8"), mode, hexsha)
+        obj = directory_to_tree(
+            path, tree.iter_child_entries(path), ie_to_hexsha, unusual_modes,
+            dummy_file_name, path == '')
 
-        if len(obj) > 0:
+        if obj is not None:
             file_id = tree.path2id(path)
             if add_cache_entry is not None:
                 add_cache_entry(obj, (file_id, tree.get_revision_id()), path)

--- a/breezy/git/object_store.py
+++ b/breezy/git/object_store.py
@@ -332,13 +332,23 @@ def _tree_to_objects(tree, parent_trees, idmap, unusual_modes,
         except KeyError:
             pass
         # FIXME: Should be the same as in parent
-        if ie.kind in ("file", "symlink"):
+        if ie.kind == "file":
             try:
                 return idmap.lookup_blob_id(ie.file_id, ie.revision)
             except KeyError:
                 # no-change merge ?
                 blob = Blob()
                 blob.data = tree.get_file_text(path)
+                if add_cache_entry is not None:
+                    add_cache_entry(blob, (ie.file_id, ie.revision), path)
+                return blob.id
+        elif ie.kind == "symlink":
+            try:
+                return idmap.lookup_blob_id(ie.file_id, ie.revision)
+            except KeyError:
+                # no-change merge ?
+                target = tree.get_symlink_target(path)
+                blob = symlink_to_blob(target)
                 if add_cache_entry is not None:
                     add_cache_entry(blob, (ie.file_id, ie.revision), path)
                 return blob.id

--- a/breezy/git/tests/test_object_store.py
+++ b/breezy/git/tests/test_object_store.py
@@ -280,7 +280,7 @@ class TreeToObjectsTests(TestCaseWithTransport):
             entries = list(_tree_to_objects(revtree_a, [basis_revtree],
                            self.idmap, {}))
             objects = {path: obj for (path, obj, key) in entries}
-            subdir_a = objects[b'foo/subdir-a']
+            subdir_a = objects['foo/subdir-a']
 
         tree_b = self.make_branch_and_tree('b')
         tree_b.pull(basis_tree.branch)


### PR DESCRIPTION
Fix a nasty corner case merging changes into a tree with changed symlinks
when pushing from bzr into git.

We were silently dropping symlink targets.