### PR TITLE
Include git-remote-bzr in python3-breezy

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -65,20 +65,26 @@ Recommends: ca-certificates,
             ssh-client | python3-paramiko,
             python3-dulwich (>= 0.19.11),
             python3-gpg,
-Conflicts: python3-paramiko (<< 1.14.1), python3-dulwich (<< 0.19.11)
+Conflicts: python3-dulwich (<< 0.19.11),
+           python3-paramiko (<< 1.14.1),
+           git-remote-bzr
+Replaces: git-remote-bzr
 Suggests: python3-breezy-dbg,
           python3-breezy.tests,
           python3-fastimport,
           python3-kerberos (>= 1.0+svn2455-1),
           python3-paramiko,
           xdg-utils,
-Provides: ${python3:Provides}
+Provides: ${python3:Provides}, git-remote-bzr
 Description: distributed version control system - Python 3 library
  Breezy is a distributed version control system designed to be easy to
  use and intuitive, able to adapt to many file formats and workflows, reliable,
  and easily extendable.
  .
  This package contains the Breezy Python 3 library.
+ .
+ This also provides the git-remote-bzr plugin for git, which allows git to use
+ a remote bzr repository.
 
 Package: python3-breezy.tests
 Architecture: all

--- a/debian/patches/26_git_remote_bzr
+++ b/debian/patches/26_git_remote_bzr
@@ -1,0 +1,115 @@
+From: Dan Streetman <ddstreet@canonical.com>
+Date: Thu, 26 Mar 2020 10:07:18 -0400
+Subject: [PATCH] git-remote-bzr: backport conversion to py3
+
+---
+ breezy/git/git-remote-bzr       | 9 ++-------
+ breezy/git/git_remote_helper.py | 8 +++-----
+ 2 files changed, 5 insertions(+), 12 deletions(-)
+
+--- a/breezy/git/git-remote-bzr
++++ b/breezy/git/git-remote-bzr
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ # vim: expandtab
+ 
+ # Copyright (C) 2011 Jelmer Vernooij <jelmer@apache.org>
+@@ -32,8 +32,6 @@ signal.signal(signal.SIGINT, handle_sigi
+ import breezy
+ breezy.initialize()
+ 
+-from breezy.sixish import PY3
+-
+ from breezy.plugin import load_plugins
+ load_plugins()
+ 
+@@ -48,7 +46,4 @@ parser = optparse.OptionParser()
+ (shortname, url) = args
+ 
+ helper = RemoteHelper(open_local_dir(), shortname, open_remote_dir(url))
+-if PY3:
+-    helper.process(sys.stdin.buffer, sys.stdout.buffer)
+-else:
+-    helper.process(sys.stdin, sys.stdout)
++helper.process(sys.stdin.buffer, sys.stdout.buffer)
+--- a/breezy/git/git_remote_helper.py
++++ b/breezy/git/git_remote_helper.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ # vim: expandtab
+ 
+ # Copyright (C) 2011-2018 Jelmer Vernooij <jelmer@jelmer.uk>
+@@ -20,8 +20,6 @@
+ 
+ """Remote helper for git for accessing bzr repositories."""
+ 
+-from __future__ import absolute_import
+-
+ CAPABILITIES = ["fetch", "option", "push"]
+ 
+ import os
+@@ -29,7 +27,6 @@ import os
+ from ..controldir import ControlDir
+ from ..errors import NotBranchError, NoRepositoryPresent
+ from ..repository import InterRepository
+-from ..sixish import viewitems
+ from ..transport import get_transport_from_path
+ 
+ from . import (
+@@ -59,6 +56,7 @@ except ImportError:
+     pass
+ else:
+     CAPABILITIES.append("import")
++    CAPABILITIES.append("refspec *:*")
+ 
+ 
+ def open_remote_dir(url):
+@@ -120,7 +118,7 @@ class RemoteHelper(object):
+         object_store = get_object_store(repo)
+         with object_store.lock_read():
+             refs = get_refs_container(self.remote_dir, object_store)
+-            for ref, git_sha1 in viewitems(refs.as_dict()):
++            for ref, git_sha1 in refs.as_dict().items():
+                 ref = ref.replace(b"~", b"_")
+                 outf.write(b"%s %s\n" % (git_sha1, ref))
+             outf.write(b"\n")
+--- a/breezy/git/tests/test_git_remote_helper.py
++++ b/breezy/git/tests/test_git_remote_helper.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ # vim: expandtab
+ 
+ # Copyright (C) 2011-2018 Jelmer Vernooij <jelmer@jelmer.uk>
+@@ -19,8 +19,6 @@
+ 
+ """Tests for the git remote helper."""
+ 
+-from __future__ import absolute_import
+-
+ from io import BytesIO
+ import os
+ import subprocess
+@@ -136,7 +134,7 @@ class RemoteHelperTests(TestCaseWithTran
+         self.helper.cmd_capabilities(f, [])
+         capabs = f.getvalue()
+         base = b"fetch\noption\npush\n"
+-        self.assertTrue(capabs in (base + b"\n", base + b"import\n\n"), capabs)
++        self.assertTrue(capabs in (base + b"\n", base + b"import\nrefspec *:*\n\n"), capabs)
+ 
+     def test_option(self):
+         f = BytesIO()
+--- a/breezy/tests/test_source.py
++++ b/breezy/tests/test_source.py
+@@ -457,6 +457,9 @@ class TestSource(TestSourceHelper):
+             if "/tests/" in fname or "test_" in fname:
+                 # We don't really care about tests
+                 continue
++            if "git_remote_helper.py" in fname:
++                # This script was updated and only supports py3
++                continue
+             if "from __future__ import absolute_import" not in text:
+                 missing_absolute_import.append(fname)
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -10,3 +10,4 @@
 23_xml_serializing
 24_paramiko_compat
 25_line_buffering
+26_git_remote_bzr

--- a/debian/rules
+++ b/debian/rules
@@ -54,21 +54,13 @@ override_dh_install:
 		xargs -r0 -i'{}' -n1 install -D -m 644 'doc/{}' \
 		"debian/brz-doc/usr/share/doc/brz/txt/{}"
 	rm debian/python3-breezy/usr/man/man1/brz.1 \
-		debian/python3-breezy/usr/man/man1/git-remote-bzr.1 \
 		debian/python3-breezy/usr/bin/bzr-receive-pack \
 		debian/python3-breezy/usr/bin/brz \
-		debian/python3-breezy/usr/bin/bzr-upload-pack \
-		debian/python3-breezy/usr/bin/git-remote-bzr
-	rmdir debian/python3-breezy/usr/man/man1 \
-		  debian/python3-breezy/usr/man
+		debian/python3-breezy/usr/bin/bzr-upload-pack
 	rm debian/python3-breezy-dbg/usr/man/man1/brz.1 \
-		debian/python3-breezy-dbg/usr/man/man1/git-remote-bzr.1 \
 		debian/python3-breezy-dbg/usr/bin/bzr-receive-pack \
 		debian/python3-breezy-dbg/usr/bin/brz \
-		debian/python3-breezy-dbg/usr/bin/bzr-upload-pack \
-		debian/python3-breezy-dbg/usr/bin/git-remote-bzr
-	rmdir debian/python3-breezy-dbg/usr/man/man1 \
-		  debian/python3-breezy-dbg/usr/man
+		debian/python3-breezy-dbg/usr/bin/bzr-upload-pack
 
 override_dh_auto_missing:
 	dh_missing --fail-missing


### PR DESCRIPTION
Since the 'git-remote-bzr' package relies on the 'bzr' package library, which has been replaced by breezy, it no longer works.  Thus, the python3-breezy package should start including the git-remote-bzr script, so people using git to connect to remove bzr repos can again use the script after upgrading relases to a version that no longer has a (working) git-remote-bzr package.  In Ubuntu, the 'git-remote-bzr' package was dropped completely starting in Eoan (19.10).

Ubuntu bug: https://bugs.launchpad.net/ubuntu/+source/breezy/+bug/1869231