### PR TITLE
Properly import the RefTracker

### DIFF
--- a/breezy/plugins/fastimport/tests/test_head_tracking.py
+++ b/breezy/plugins/fastimport/tests/test_head_tracking.py
@@ -24,7 +24,7 @@ from fastimport import (
 
 import testtools
 
-from .reftracker import (
+from fastimport.reftracker import (
     RefTracker,
     )
 


### PR DESCRIPTION
If you do just .reftracker and execute all the tests ie using pytest it would fail on import error as the pwd is containing different value.