### PR TITLE
Convert integer marks to string in fast-export

### DIFF
--- a/breezy/plugins/fastimport/marks_file.py
+++ b/breezy/plugins/fastimport/marks_file.py
@@ -76,7 +76,11 @@ def export_marks(filename, revision_ids):
     try:
         # Write the revision info
         for mark in revision_ids:
-            f.write(':%s %s\n' % (mark.lstrip(b':').decode('utf-8'),
+            if isinstance(mark, int):
+                mark_name = str(mark)
+            elif isinstance(mark, bytes):
+                mark_name = mark.lstrip(b':').decode('utf-8')
+            f.write(':%s %s\n' % (mark_name,
                                   revision_ids[mark].decode('utf-8')))
     finally:
         f.close()


### PR DESCRIPTION
When using `fast-export --export-marks` I would get an error like this

```
bkhl@toolbox:.../foo/custom$ brz fast-export --export-marks=../marks.bzr ../bzr/trunk/ > /dev/null
16:59:32 Calculating the revisions to include ...
16:59:32 Starting export of 1108 revisions ...
16:59:34 1000/1108 commits exported at 32153/minute 
brz: ERROR: AttributeError: 'int' object has no attribute 'lstrip'

Traceback (most recent call last):
  File "/usr/lib64/python3.8/site-packages/breezy/commands.py", line 1016, in exception_to_return_code
    return the_callable(*args, **kwargs)
  File "/usr/lib64/python3.8/site-packages/breezy/commands.py", line 1202, in run_bzr
    ret = run(*run_argv)
  File "/usr/lib64/python3.8/site-packages/breezy/commands.py", line 759, in run_argv_aliases
    return self.run(**all_cmd_args)
  File "/usr/lib64/python3.8/site-packages/breezy/commands.py", line 784, in run
    return self._operation.run_simple(*args, **kwargs)
  File "/usr/lib64/python3.8/site-packages/breezy/cleanup.py", line 136, in run_simple
    return _do_with_cleanups(
  File "/usr/lib64/python3.8/site-packages/breezy/cleanup.py", line 166, in _do_with_cleanups
    result = func(*args, **kwargs)
  File "/usr/lib64/python3.8/site-packages/breezy/plugins/fastimport/cmds.py", line 507, in run
    return exporter.run()
  File "/usr/lib64/python3.8/site-packages/breezy/plugins/fastimport/exporter.py", line 258, in run
    self._save_marks()
  File "/usr/lib64/python3.8/site-packages/breezy/plugins/fastimport/exporter.py", line 306, in _save_marks
    marks_file.export_marks(self.export_marks_file, revision_ids)
  File "/usr/lib64/python3.8/site-packages/breezy/plugins/fastimport/marks_file.py", line 83, in export_marks
    f.write(':%s %s\n' % (mark.lstrip(b':').decode('utf-8'),
AttributeError: 'int' object has no attribute 'lstrip'

brz 3.0.2 on python 3.8.2rc2 (Linux-5.6.19-300.fc32.x86_64-x86_64-with-
    glibc2.2.5)
arguments: ['/usr/bin/brz', 'fast-export', '--export-marks=../marks.bzr',
```

This patch converts incoming `bytes` or `int` objects to strings appropriately.

Not sure if this is necessary though. Can we maybe just assume the marks are always going to be `int`s?

Submitting this as a PR for feedback.