### PR TITLE
Open stdin in binary mode

### DIFF
--- a/breezy/plugins/fastimport/cmds.py
+++ b/breezy/plugins/fastimport/cmds.py
@@ -51,7 +51,10 @@ def _run(source, processor_factory, verbose=False, user_map=None, **kwargs):
 def _get_source_stream(source):
     if source == '-' or source is None:
         import sys
-        stream = helpers.binary_stream(sys.stdin)
+        try:
+            stream = sys.stdin.buffer
+        except AttributeError:
+            stream = helpers.binary_stream(sys.stdin)
     elif source.endswith('.gz'):
         import gzip
         stream = gzip.open(source, "rb")


### PR DESCRIPTION
In Python 3 `sys.stdin` is in text mode and `sys.stdin.buffer` needs to be used to get the binary buffer

Otherwise you get failures such as

```
$ (cd languages ; git fast-export -M --all) | (cd bzr-repo; bzr fast-import -)
12:05:02 Starting import ...
brz: ERROR: TypeError: startswith first arg must be str or a tuple of str, not bytes

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/breezy/commands.py", line 1016, in exception_to_return_code
    return the_callable(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/breezy/commands.py", line 1202, in run_bzr
    ret = run(*run_argv)
  File "/usr/lib/python3/dist-packages/breezy/commands.py", line 759, in run_argv_aliases
    return self.run(**all_cmd_args)
  File "/usr/lib/python3/dist-packages/breezy/commands.py", line 784, in run
    return self._operation.run_simple(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/breezy/cleanup.py", line 136, in run_simple
    return _do_with_cleanups(
  File "/usr/lib/python3/dist-packages/breezy/cleanup.py", line 166, in _do_with_cleanups
    result = func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/breezy/plugins/fastimport/cmds.py", line 320, in run
    return _run(source, generic_processor.GenericProcessor,
  File "/usr/lib/python3/dist-packages/breezy/plugins/fastimport/cmds.py", line 51, in _run
    return proc.process(p.iter_commands)
  File "/usr/lib/python3/dist-packages/breezy/plugins/fastimport/processors/generic_processor.py", line 282, in process
    super(GenericProcessor, self)._process(command_iter)
  File "/usr/lib/python3/dist-packages/fastimport/processor.py", line 79, in _process
    for cmd in command_iter():
  File "/usr/lib/python3/dist-packages/fastimport/parser.py", line 298, in iter_commands
    elif len(line) == 0 or line.startswith(b'#'):
TypeError: startswith first arg must be str or a tuple of str, not bytes
```