### PR TITLE
Remove pkg-version dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,4 @@ name = "brz"
 path = "breezy/main.rs"
 
 [dependencies]
-pkg-version = "1.0.0"
 pyo3 = ">=0.14,<0.16"

--- a/breezy/main.rs
+++ b/breezy/main.rs
@@ -1,13 +1,12 @@
-use pkg_version::*;
 use pyo3::prelude::*;
 use pyo3::types::*;
 use std::path::*;
 
-const MAJOR: u32 = pkg_version_major!();
-const MINOR: u32 = pkg_version_minor!();
-const PATCH: u32 = pkg_version_patch!();
 
 fn check_version(py: Python<'_>) -> PyResult<()> {
+    let MAJOR: u32 = env!("CARGO_PKG_VERSION_MAJOR").parse::<u32>().unwrap();
+    let MINOR: u32 = env!("CARGO_PKG_VERSION_MINOR").parse::<u32>().unwrap();
+    let PATCH: u32 = env!("CARGO_PKG_VERSION_PATCH").parse::<u32>().unwrap();
     let breezy = PyModule::import(py, "breezy").map_err(|e| {
         eprintln!(
             "brz: ERROR: Couldn't import breezy and dependencies.\n\


### PR DESCRIPTION
Parse envar CARGO_PKG_VERSION without pkg-version rust dependency.

In order to reduce the number of dependencies that needs to be shipped with breezy, I propose removing pkg-version rust dependency and replace it with one-liners that parse the envar.

Could you please take a look and review these changes