### PR TITLE
Bump python versions for Windows and Mac OS X to 3.12

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,9 +15,9 @@ jobs:
         include:
           - os: macos-latest
             experimental: true
-            python-version: 3.7
+            python-version: '3.12'
           - os: windows-latest
-            python-version: 3.7
+            python-version: '3.12'
             experimental: true
 # See https://github.com/actions/toolkit/issues/399
 #        include:


### PR DESCRIPTION
Python 3.7 is EOL and GitHub no longer provides it.