### PR TITLE
Skip public HTTP construction URL for LP private bzr branches

### DIFF
--- a/breezy/plugins/launchpad/lp_directory.py
+++ b/breezy/plugins/launchpad/lp_directory.py
@@ -90,12 +90,19 @@ def _resolve_via_api(path, url, api_base_url=LPNET_SERVICE_ROOT):
         path, subpath = split(path)
         subpaths.insert(0, subpath)
     if lp_branch:
-        return {
-            "urls": [
-                join(lp_branch.composePublicURL(scheme="bzr+ssh"), *subpaths),
-                join(lp_branch.composePublicURL(scheme="http"), *subpaths),
-            ]
-        }
+        urls = [
+            join(lp_branch.composePublicURL(scheme="bzr+ssh"), *subpaths)
+        ]
+        # Private Launchpad bzr branches do not have a public HTTP URL.
+        # Calling .composePublicURL() on them causes the Launchpad API
+        # to error out and return a 500 error status code as reported
+        # https://bugs.launchpad.net/brz/+bug/2039396. So do not try to
+        # construct one.
+        if not lp_branch.private:
+            urls.append(
+                join(lp_branch.composePublicURL(scheme="http"), *subpaths)
+            )
+        return {"urls": urls}
     elif git_repo:
         return {
             "urls": [


### PR DESCRIPTION
LP private branches are not accessible over HTTP and the Launchpad API errors out and returns a 500 error when the .composePublicURL() API method is invoked on a private branch. This causes errors when trying to branch private bzr branches from LP as reported in https://bugs.launchpad.net/brz/+bug/2039396.

@jelmer, as there aren't any existing tests for breezy code that uses this part of Launchpad infrastructure and adding one for this change will likely require mocking multiple layers, I haven't attempted to add any tests. If you'd like to have some tests implemented for this as a pre-merge criteria, let me know and I will try to do so.

