### PR TITLE
Fix calling obsolete `PyInt_AsUnsignedLongMask`

### DIFF
--- a/breezy/bzr/_dirstate_helpers_pyx.pyx
+++ b/breezy/bzr/_dirstate_helpers_pyx.pyx
@@ -102,7 +102,7 @@ cdef extern from "Python.h":
     object PyTuple_GetItem_void_object "PyTuple_GET_ITEM" (void* tpl, int index)
     object PyTuple_GET_ITEM(object tpl, Py_ssize_t index)
 
-    unsigned long PyInt_AsUnsignedLongMask(object number) except? -1
+    unsigned long PyLong_AsUnsignedLongMask(object number) except? -1
 
     char *PyBytes_AsString(object p)
     char *PyBytes_AsString_obj "PyBytes_AsString" (PyObject *string)
@@ -467,7 +467,7 @@ _encode = binascii.b2a_base64
 cdef unsigned long _time_to_unsigned(object t):  # cannot_raise
     if PyFloat_Check(t):
         t = t.__int__()
-    return PyInt_AsUnsignedLongMask(t)
+    return PyLong_AsUnsignedLongMask(t)
 
 
 cdef _pack_stat(stat_value):
@@ -479,13 +479,13 @@ cdef _pack_stat(stat_value):
     cdef char result[6*4] # 6 long ints
     cdef int *aliased
     aliased = <int *>result
-    aliased[0] = htonl(PyInt_AsUnsignedLongMask(stat_value.st_size))
+    aliased[0] = htonl(PyLong_AsUnsignedLongMask(stat_value.st_size))
     # mtime and ctime will often be floats but get converted to PyInt within
     aliased[1] = htonl(_time_to_unsigned(stat_value.st_mtime))
     aliased[2] = htonl(_time_to_unsigned(stat_value.st_ctime))
-    aliased[3] = htonl(PyInt_AsUnsignedLongMask(stat_value.st_dev))
-    aliased[4] = htonl(PyInt_AsUnsignedLongMask(stat_value.st_ino))
-    aliased[5] = htonl(PyInt_AsUnsignedLongMask(stat_value.st_mode))
+    aliased[3] = htonl(PyLong_AsUnsignedLongMask(stat_value.st_dev))
+    aliased[4] = htonl(PyLong_AsUnsignedLongMask(stat_value.st_ino))
+    aliased[5] = htonl(PyLong_AsUnsignedLongMask(stat_value.st_mode))
     packed = PyBytes_FromStringAndSize(result, 6*4)
     return _encode(packed)[:-1]
 


### PR DESCRIPTION
Replace the calls to obsolete `PyInt_AsUnsignedLongMask()` with the Python 3.x equivalent of `PyLong_AsUnsignedLongMask()`.  This fixes the following build error:

```
[1/1] Cythonizing breezy/bzr/_dirstate_helpers_pyx.pyx
building 'breezy.bzr._dirstate_helpers_pyx' extension
x86_64-pc-linux-gnu-gcc -fno-strict-overflow -Wsign-compare -fPIC -Ibreezy -I/tmp/breezy/.venv/include -I/usr/include/python3.13 -c breezy/bzr/_dirstate_helpers_pyx.c -o build/temp.linux-x86_64-cpython-313/breezy/bzr/_dirstate_helpers_pyx.o
breezy/bzr/_dirstate_helpers_pyx.c: In function ‘__pyx_f_6breezy_3bzr_21_dirstate_helpers_pyx__time_to_unsigned’:
breezy/bzr/_dirstate_helpers_pyx.c:6714:15: error: implicit declaration of function ‘PyInt_AsUnsignedLongMask’; did you mean ‘PyLong_AsUnsignedLongMask’? [-Wimplicit-function-declaration]
 6714 |   __pyx_t_5 = PyInt_AsUnsignedLongMask(__pyx_v_t); if (unlikely(__pyx_t_5 == ((unsigned long)-1) && PyErr_Occurred())) __PYX_ERR(0, 470, __pyx_L1_error)
      |               ^~~~~~~~~~~~~~~~~~~~~~~~
      |               PyLong_AsUnsignedLongMask
warning: build_ext_rust_extension: building extension "breezy.bzr._dirstate_helpers_pyx" failed: command '/usr/bin/x86_64-pc-linux-gnu-gcc' failed with exit code 1
```