### PR TITLE
launchpad: Add warning about Bazaar code hosting phase-out

### DIFF
--- a/breezy/plugins/launchpad/__init__.py
+++ b/breezy/plugins/launchpad/__init__.py
@@ -35,11 +35,19 @@ The plugin also provides the following commands:
 # see http://wiki.bazaar.canonical.com/Specs/BranchRegistrationTool
 
 from ... import (
+    ui,
     version_info,  # noqa: F401
 )
 from ...commands import plugin_cmds
 from ...directory_service import directories
 from ...help_topics import topic_registry
+
+# Register the Bazaar deprecation warning template
+ui.UIFactory._user_warning_templates["launchpad_bazaar_deprecation"] = (
+    "Launchpad is phasing out Bazaar code hosting. "
+    "For more information, see: "
+    "https://blog.launchpad.net/general/phasing-out-bazaar-code-hosting"
+)
 
 for klsname, aliases in [
     ("cmd_launchpad_open", ["lp-open"]),
@@ -88,6 +96,9 @@ _launchpad_help = """Integration with Launchpad.net
 
 Launchpad.net provides free Bazaar branch hosting with integrated bug and
 specification tracking.
+
+NOTE: Launchpad is phasing out Bazaar code hosting. For more information, see:
+https://blog.launchpad.net/general/phasing-out-bazaar-code-hosting
 
 The bzr client (through the plugin called 'launchpad') has special
 features to communicate with Launchpad:

--- a/breezy/plugins/launchpad/forge.py
+++ b/breezy/plugins/launchpad/forge.py
@@ -430,6 +430,9 @@ class Launchpad(Forge):
         allow_lossy=True,
         tag_selector=None,
     ):
+        from ... import ui
+
+        ui.ui_factory.show_user_warning("launchpad_bazaar_deprecation")
         to_path = self._get_derived_bzr_path(base_branch, name, owner, project)
         to_transport = get_transport(BZR_SCHEME_MAP["ssh"] + to_path)
         try:

--- a/breezy/plugins/launchpad/lp_directory.py
+++ b/breezy/plugins/launchpad/lp_directory.py
@@ -18,7 +18,7 @@
 
 from urllib.parse import urlsplit
 
-from ... import debug, errors, trace, transport
+from ... import debug, errors, trace, transport, ui
 from ...urlutils import InvalidURL, join, split
 from .account import get_lp_login
 from .uris import LPNET_SERVICE_ROOT
@@ -92,6 +92,7 @@ def _resolve_via_api(path, url, api_base_url=LPNET_SERVICE_ROOT):
         path, subpath = split(path)
         subpaths.insert(0, subpath)
     if lp_branch:
+        ui.ui_factory.show_user_warning("launchpad_bazaar_deprecation")
         return {
             "urls": [
                 join(lp_branch.composePublicURL(scheme="bzr+ssh"), *subpaths),

--- a/doc/en/release-notes/brz-3.3.txt
+++ b/doc/en/release-notes/brz-3.3.txt
@@ -10,6 +10,11 @@ brz 3.3.13
 
 :3.3.13: UNRELEASED
 
+* Add warning when accessing Bazaar branches on Launchpad, as Launchpad
+  is phasing out Bazaar code hosting. The warning can be suppressed by
+  adding ``launchpad_bazaar_deprecation`` to the ``suppress_warnings``
+  configuration option. (Jelmer Vernooĳ)
+
 brz 3.3.12
 ##########
 


### PR DESCRIPTION
When users access Bazaar branches on Launchpad (via lp: URLs or when publishing branches), display a warning that Launchpad is phasing out Bazaar code hosting. The warning includes a link to the announcement blog post and can be suppressed by adding 'launchpad_bazaar_deprecation' to the suppress_warnings configuration option.