### PR TITLE
added openbsd support

### DIFF
--- a/breezy/i18n.py
+++ b/breezy/i18n.py
@@ -78,7 +78,7 @@ def install(lang=None):
         return
     if lang is None:
         lang = _get_current_locale()
-    if (lang == "C") or lang.startswith("C."):
+    if not lang or (lang == "C") or lang.startswith("C."):
         # Nothing to be done for C locale
         _i18n_rs.disable_i18n()
     else:

--- a/crates/osutils/src/mounts-unix.rs
+++ b/crates/osutils/src/mounts-unix.rs
@@ -82,7 +82,7 @@ fn load_mounts() -> Vec<MountEntry> {
     mounts
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "openbsd"))]
 fn parse_mount_line(line: &str) -> Option<MountEntry> {
     if line.is_empty() {
         return None;
@@ -104,7 +104,7 @@ fn parse_mount_line(line: &str) -> Option<MountEntry> {
     })
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "openbsd"))]
 #[test]
 fn test_parse_mount_line() {
     let line = "devfs on /dev (devfs, local, nobrowse)";
@@ -114,9 +114,9 @@ fn test_parse_mount_line() {
     assert_eq!(mount_entry.options, "local, nobrowse");
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "openbsd"))]
 fn load_mounts() -> Vec<MountEntry> {
-    // macOS does not have a /proc/mounts equivalent, so we use the output of
+    // BSD does not have a /proc/mounts equivalent, so we use the output of
     // `mount` command
     //
     // TODO: find a more robust and efficient way to get mount information

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,14 +58,15 @@ fn prepend_path(py: Python<'_>, el: &Path) -> PyResult<()> {
 
 // Prepend sys.path with the brz path when useful.
 fn update_path(py: Python<'_>) -> PyResult<()> {
-    let mut path = std::env::current_exe()?;
+    if let Ok(mut path) = std::env::current_exe() {
 
-    path.pop(); // Drop executable name
+      path.pop(); // Drop executable name
 
-    let mut package_path = path.clone();
-    package_path.push("breezy");
-    if package_path.is_dir() {
-        prepend_path(py, path.as_path())?;
+      let mut package_path = path.clone();
+      package_path.push("breezy");
+      if package_path.is_dir() {
+          prepend_path(py, path.as_path())?;
+      }
     }
 
     Ok(())


### PR DESCRIPTION
This is what I needed to change in order to get it to run on openbsd. 
* the `not lang` was needed because _get_current_locale() may return None in the case when none of the environment variables it looks for is set.
* added openbsd to the list of bsd based systems
* rust std::env::current_exe() returns None on OpenBSD when the executable is relative to the $PATH as described in [this issue](https://github.com/rust-lang/rust/issues/60560)
