### PR TITLE
Support bearer-token auth in authentication.conf

### DIFF
--- a/breezy/config.py
+++ b/breezy/config.py
@@ -1587,14 +1587,18 @@ class AuthenticationConfig:
           This includes:
            - name: the section name of the credentials in the
              authentication.conf file,
-           - user: can't be different from the provided user if any,
+           - user: can't be different from the provided user if any. May be
+             None for token-only entries.
            - scheme: the server protocol,
            - host: the server address,
            - port: the server port (can be None),
            - path: the absolute server path (can be None),
            - realm: the http specific authentication realm (can be None),
            - password: the decoded password, could be None if the credential
-             defines only the user
+             defines only the user or only a token
+           - token: bearer token to send via Authorization header, or None
+           - token_scheme: HTTP auth scheme to use with the token (defaults
+             to "Bearer"),
            - verify_certificates: https specific, True if the server
              certificate should be verified, False otherwise.
         """
@@ -1606,6 +1610,7 @@ class AuthenticationConfig:
             a_scheme, a_host, a_user, a_path = map(
                 auth_def.get, ["scheme", "host", "user", "path"]
             )
+            a_token = auth_def.get("token")
 
             try:
                 a_port = auth_def.as_int("port")
@@ -1637,8 +1642,8 @@ class AuthenticationConfig:
             if a_user is not None and user is not None and a_user != user:
                 # Never contradict the caller about the user to be used
                 continue
-            if a_user is None:
-                # Can't find a user
+            if a_user is None and a_token is None:
+                # No user and no token — nothing useful in this section
                 continue
             # Prepare a credentials dictionary with additional keys
             # for the credential providers
@@ -1651,6 +1656,8 @@ class AuthenticationConfig:
                 "path": path,
                 "realm": realm,
                 "password": auth_def.get("password", None),
+                "token": a_token,
+                "token_scheme": auth_def.get("token_scheme", "Bearer"),
                 "verify_certificates": a_verify_certificates,
             }
             # Decode the password in the credentials (or get one)
@@ -1667,6 +1674,27 @@ class AuthenticationConfig:
             )
 
         return credentials
+
+    def get_token(self, scheme, host, port=None, path=None, realm=None):
+        """Get a bearer token from the authentication file, if configured.
+
+        Args:
+          scheme: protocol
+          host: the server address
+          port: the associated port (optional)
+          path: the absolute path on the server (optional)
+          realm: the http specific authentication realm (optional)
+
+        Returns:
+          A (token, token_scheme) tuple, or (None, None) if no token is
+          configured for this location.
+        """
+        credentials = self.get_credentials(
+            scheme, host, port=port, user=None, path=path, realm=realm
+        )
+        if credentials is None:
+            return None, None
+        return credentials.get("token"), credentials.get("token_scheme") or "Bearer"
 
     def set_credentials(
         self,

--- a/breezy/plugins/github/forge.py
+++ b/breezy/plugins/github/forge.py
@@ -65,6 +65,8 @@ def store_github_token(token):
     auth_config = AuthenticationConfig()
     auth_config._set_option("Github", "scheme", "https")
     auth_config._set_option("Github", "url", API_GITHUB_URL)
+    auth_config._set_option("Github", "host", GITHUB_HOST)
+    auth_config._set_option("Github", "token", token)
     auth_config._set_option("Github", "private_token", token)
 
 

--- a/breezy/plugins/gitlab/forge.py
+++ b/breezy/plugins/gitlab/forge.py
@@ -152,9 +152,14 @@ def store_gitlab_token(name, url, private_token):
     """Store a GitLab token in a configuration file."""
     from breezy.config import AuthenticationConfig
 
+    (scheme, _user, _password, host, _port, _path) = urlutils.parse_url(url)
     auth_config = AuthenticationConfig()
     auth_config._set_option(name, "url", url)
     auth_config._set_option(name, "forge", "gitlab")
+    auth_config._set_option(name, "scheme", scheme or "https")
+    if host:
+        auth_config._set_option(name, "host", host)
+    auth_config._set_option(name, "token", private_token)
     auth_config._set_option(name, "private_token", private_token)
 
 

--- a/breezy/tests/test_config.py
+++ b/breezy/tests/test_config.py
@@ -4505,6 +4505,8 @@ class TestAuthenticationStorage(tests.TestCaseInTempDir):
             "port": 99,
             "path": "/foo",
             "realm": "realm",
+            "token": None,
+            "token_scheme": "Bearer",
         }
         self.assertEqual(CREDENTIALS, credentials)
         credentials_from_disk = config.AuthenticationConfig().get_credentials(
@@ -4528,6 +4530,8 @@ class TestAuthenticationStorage(tests.TestCaseInTempDir):
             "port": None,
             "path": None,
             "realm": None,
+            "token": None,
+            "token_scheme": "Bearer",
         }
         self.assertEqual(CREDENTIALS, credentials)
 

--- a/breezy/tests/test_http.py
+++ b/breezy/tests/test_http.py
@@ -1593,6 +1593,87 @@ class TestUrllib2AuthHandler(tests.TestCaseWithTransport):
         self.assertEqual((user, password), got_pass)
 
 
+class TestTokenAuthHeader(tests.TestCaseInTempDir):
+    """Preemptive Authorization header derived from an authentication.conf token."""
+
+    def _make_transport(self, base_url="https://example.com/"):
+        from ..transport.http.urllib import HttpTransport
+
+        return HttpTransport(base_url)
+
+    def test_no_token_configured(self):
+        _setup_authentication_config(scheme="https", host="other.com", token="abc")
+        t = self._make_transport()
+        self.assertIsNone(t._token_auth_header("https://example.com/foo"))
+
+    def test_token_matches_host(self):
+        _setup_authentication_config(scheme="https", host="example.com", token="abc")
+        t = self._make_transport()
+        self.assertEqual("Bearer abc", t._token_auth_header("https://example.com/foo"))
+
+    def test_token_scheme_override(self):
+        _setup_authentication_config(
+            scheme="https",
+            host="example.com",
+            token="abc",
+            token_scheme="token",
+        )
+        t = self._make_transport()
+        self.assertEqual("token abc", t._token_auth_header("https://example.com/foo"))
+
+    def test_token_host_mismatch(self):
+        _setup_authentication_config(scheme="https", host="example.com", token="abc")
+        t = self._make_transport()
+        self.assertIsNone(t._token_auth_header("https://other.com/foo"))
+
+    def test_invalid_url(self):
+        _setup_authentication_config(scheme="https", host="example.com", token="abc")
+        t = self._make_transport()
+        self.assertIsNone(t._token_auth_header("not a url"))
+
+    def test_request_attaches_authorization_header(self):
+        _setup_authentication_config(scheme="https", host="example.com", token="abc")
+        t = self._make_transport()
+        captured = {}
+
+        def fake_open(request):
+            captured["headers"] = dict(request.header_items())
+            raise RuntimeError("stop here")
+
+        t._opener.open = fake_open
+        try:
+            t.request("GET", "https://example.com/foo")
+        except RuntimeError:
+            pass
+        self.assertEqual(
+            "Bearer abc",
+            captured["headers"].get("Authorization"),
+        )
+
+    def test_request_does_not_override_caller_authorization(self):
+        _setup_authentication_config(scheme="https", host="example.com", token="abc")
+        t = self._make_transport()
+        captured = {}
+
+        def fake_open(request):
+            captured["headers"] = dict(request.header_items())
+            raise RuntimeError("stop here")
+
+        t._opener.open = fake_open
+        try:
+            t.request(
+                "GET",
+                "https://example.com/foo",
+                headers={"Authorization": "Custom keep-me"},
+            )
+        except RuntimeError:
+            pass
+        self.assertEqual(
+            "Custom keep-me",
+            captured["headers"].get("Authorization"),
+        )
+
+
 class TestAuth(http_utils.TestCaseWithWebserver):
     """Test authentication scheme."""
 

--- a/breezy/transport/http/urllib.py
+++ b/breezy/transport/http/urllib.py
@@ -1864,6 +1864,10 @@ class HttpTransport(ConnectedTransport):
             data = body
         if headers is None:
             headers = {}
+        if not any(h.lower() == "authorization" for h in headers):
+            token_header = self._token_auth_header(url)
+            if token_header is not None:
+                headers["Authorization"] = token_header
         request = Request(method, url, data, headers)
         request.follow_redirections = urlopen_kw.pop("retries", 0) > 0
         if urlopen_kw:
@@ -2066,6 +2070,29 @@ class HttpTransport(ConnectedTransport):
             "path": self._parsed_url.path,
         }
         return auth
+
+    def _token_auth_header(self, url):
+        """Build an Authorization header from a configured bearer token, if any.
+
+        Returns the formatted header value (e.g. "Bearer abc123") for the
+        request URL, or None when no token is configured for that location.
+        Tokens are looked up in authentication.conf via
+        :class:`config.AuthenticationConfig` and applied preemptively (no
+        server challenge required), unlike Basic/Digest auth.
+        """
+        try:
+            parsed = urlutils.URL.from_string(url)
+        except urlutils.InvalidURL:
+            return None
+        token, scheme = config.AuthenticationConfig().get_token(
+            parsed.scheme,
+            parsed.host,
+            port=parsed.port,
+            path=parsed.path,
+        )
+        if not token:
+            return None
+        return "{} {}".format(scheme, token)
 
     def get_smart_medium(self):
         """See Transport.get_smart_medium."""

--- a/doc/en/release-notes/brz-3.3.txt
+++ b/doc/en/release-notes/brz-3.3.txt
@@ -8,6 +8,12 @@ Breezy Release Notes
 brz 3.3.22
 ##########
 
+ * Honour ``token`` entries in ``authentication.conf`` by sending an
+   ``Authorization`` header preemptively over HTTP. ``brz gh-login`` and
+   ``brz gitlab-login`` now write a ``token`` field, so subsequent git
+   smart-HTTP fetch and push traffic to GitHub and GitLab reuses the
+   forge credentials rather than going anonymous. (Jelmer Vernooĳ)
+
  * Use the ``vcsgraph`` package for graph, topological sort and
    known graph implementations rather than local copies.
    (Jelmer Vernooĳ)


### PR DESCRIPTION
Add a `token` field (optionally with `token_scheme`, default `Bearer`) to authentication.conf sections. The HTTP transport reads it via the new `AuthenticationConfig.get_token()` and attaches `Authorization: <scheme> <token>` preemptively, so unlike Basic/Digest no 401 challenge is required. A caller-supplied `Authorization` header is left untouched.

`store_github_token` and `store_gitlab_token` now write `host`, `scheme` and `token` alongside the existing `private_token`. This makes git smart-HTTP fetch and push reuse the forge credentials, both authenticating against private repos and lifting anonymous rate limits, instead of going anonymous.

Existing sections that only carry `private_token` won't be picked up by the transport - users will need to re-run `gh-login` / `gitlab-login` to populate the new fields.