### PR TITLE
trace: route Rust log output through Python's logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,14 +261,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "breezy-readdir"
-version = "3.4.0"
-dependencies = [
- "libc",
- "nix",
-]
-
-[[package]]
 name = "breezy-zlib-util"
 version = "3.4.0"
 dependencies = [
@@ -326,6 +327,7 @@ dependencies = [
  "log",
  "pyo3",
  "pyo3-filelike",
+ "pyo3-log",
 ]
 
 [[package]]
@@ -1406,6 +1408,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3-log"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c2ec80932c5c3b2d4fbc578c9b56b2d4502098587edb8bef5b6bfcad43682e"
+dependencies = [
+ "arc-swap",
+ "log",
+ "pyo3",
+]
+
+[[package]]
 name = "pyo3-macros"
 version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,16 +1576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "readdir-py"
-version = "3.4.0"
-dependencies = [
- "breezy-readdir",
- "libc",
- "nix",
- "pyo3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ dirs = "6"
 nix = ">=0.26"
 pyo3 = "0.28"
 pyo3-filelike = "0.5.2"
+pyo3-log = "0.13"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 url = "2"
 log = "0.4"

--- a/breezy/tests/test_trace.py
+++ b/breezy/tests/test_trace.py
@@ -311,11 +311,9 @@ class TestTrace(TestCase):
             tmp2.close()
 
     def test__open_brz_log_uses_stderr_for_failures(self):
-        # If _open_brz_log cannot open the file, then we should write the
-        # warning to stderr. Since this is normally happening before logging is
-        # set up.
-        self.overrideAttr(sys, "stderr", StringIO())
-        # Set the log file to something that cannot exist
+        # If _open_brz_log cannot open the file, the failure is routed through
+        # the `brz` logger so the test fixture's in-memory log attachment
+        # captures it (rather than leaking to the real stderr).
         self.overrideEnv("BRZ_LOG", "/no-such-dir/brz.log")
         old_brz_log_filename = trace.get_brz_log_filename()
         self.addCleanup(trace.set_brz_log_filename, old_brz_log_filename)
@@ -323,21 +321,16 @@ class TestTrace(TestCase):
         if os.path.isdir("/no-such-dir"):
             raise TestSkipped("directory creation succeeded")
         self.assertIs(None, logf)
-
-        self.expectFailure(
-            "This test currently fails because brz's testsuite doesn't capture "
-            "error output from rust",
-            self.assertContainsRe,
-            sys.stderr.getvalue(),
-            "failed to open trace file: .* '/no-such-dir/brz.log'$",
+        self.assertContainsRe(
+            self.get_log(),
+            r"failed to open trace file: /no-such-dir/brz\.log: ",
         )
 
     def test__open_brz_log_ignores_cache_dir_error(self):
-        # If the cache directory can not be created and _open_brz_log can thus
-        # not open the file, then we should write the warning to stderr. Since
-        # this is normally happening before logging is set up.
-        self.overrideAttr(sys, "stderr", StringIO())
-        # Set the cache directory to something that cannot exist
+        # If the cache directory cannot be created and _open_brz_log thus
+        # cannot open the file, the failure is routed through the `brz`
+        # logger so the test fixture captures it as part of the test's
+        # attached log output.
         self.overrideEnv("BRZ_LOG", None)
         self.overrideEnv("BRZ_HOME", "/no-such-dir")
         self.overrideEnv("XDG_CACHE_HOME", "/no-such-dir")
@@ -347,12 +340,9 @@ class TestTrace(TestCase):
         if os.path.isdir("/no-such-dir"):
             raise TestSkipped("directory creation succeeded")
         self.assertIs(None, logf)
-        self.expectFailure(
-            "This test currently fails because brz's testsuite doesn't capture "
-            "error output from rust",
-            self.assertContainsRe,
-            sys.stderr.getvalue(),
-            "failed to open trace file: .* /no-such-dir.*$",
+        self.assertContainsRe(
+            self.get_log(),
+            r"failed to open trace file:.*/no-such-dir",
         )
 
 

--- a/crates/cmd-py/Cargo.toml
+++ b/crates/cmd-py/Cargo.toml
@@ -13,6 +13,7 @@ i18n = ["gettext", "breezy/i18n"]
 [dependencies]
 pyo3 = { workspace = true, features = ["extension-module"]}
 pyo3-filelike = { workspace = true }
+pyo3-log = { workspace = true }
 breezy = { path = "../..", features = ["pyo3"], default-features = false }
 gettext = { workspace = true, optional = true }
 log = { workspace = true, features=["std"]}

--- a/crates/cmd-py/src/lib.rs
+++ b/crates/cmd-py/src/lib.rs
@@ -655,6 +655,15 @@ fn remove_tags(
 
 #[pymodule]
 fn _cmd_rs(py: Python, m: &Bound<PyModule>) -> PyResult<()> {
+    // Route Rust `log` records to Python's `logging` module so that fixtures
+    // like the test suite's `breezy.trace.push_log_file` see them. Without
+    // this, Rust code that hits `log::warn!` etc. (or that fell back to
+    // `eprintln!` for things like "failed to open trace file") would bypass
+    // every Python-side handler and leak to the real stderr.
+    //
+    // `try_init` is used so re-imports of this extension module don't panic.
+    let _ = pyo3_log::try_init();
+
     let i18n = PyModule::new(py, "i18n")?;
     i18n.add_function(wrap_pyfunction!(i18n_install, &i18n)?)?;
     i18n.add_function(wrap_pyfunction!(i18n_install_plugin, &i18n)?)?;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,4 +1,4 @@
-use log::info;
+use log::{info, warn};
 use std::fs::{File, OpenOptions};
 use std::io::Read;
 use std::io::{self, Write};
@@ -117,18 +117,26 @@ pub fn set_brz_log_filename(filename: Option<&Path>) {
 ///
 /// This sets the global `_brz_log_filename`.
 pub fn open_brz_log() -> Option<File> {
-    let filename = initialize_brz_log_filename().ok()?;
+    // Route failures via the `log` facade so Python-side handlers (including
+    // the test suite's in-memory log capture installed by
+    // `breezy.trace.push_log_file`) receive the message instead of it being
+    // written directly to stderr, which bypasses test redirection. The
+    // target is "brz" so it lands on the same Python logger that holds the
+    // BreezyTraceHandler.
+    let filename = match initialize_brz_log_filename() {
+        Ok(filename) => filename,
+        Err(e) => {
+            warn!(target: "brz", "failed to open trace file: {}", e);
+            return None;
+        }
+    };
     set_brz_log_filename(Some(filename.as_path()));
     rollover_trace_maybe(&filename).ok();
 
     let mut brz_log_file = match open_or_create_log_file(&filename) {
         Ok(fd) => fd,
         Err(e) => {
-            // If we are failing to open the log, then most likely logging has not
-            // been set up yet. So we just write to stderr rather than using 'warning()'.
-            // If we use warning(), users get the unhelpful 'no handlers registered for "brz"'
-            // when something goes wrong on the server. (bug #503886)
-            eprintln!("failed to open trace file: {}: {}", filename.display(), e);
+            warn!(target: "brz", "failed to open trace file: {}: {}", filename.display(), e);
             return None;
         }
     };
@@ -139,19 +147,19 @@ pub fn open_brz_log() -> Option<File> {
             brz_log_file,
             "this is a debug log for diagnosing/reporting problems in brz"
         ) {
-            eprintln!("failed to write to trace file: {}", e);
+            warn!(target: "brz", "failed to write to trace file: {}", e);
         }
         if let Err(e) = writeln!(
             brz_log_file,
             "you can delete or truncate this file, or include sections in"
         ) {
-            eprintln!("failed to write to trace file: {}", e);
+            warn!(target: "brz", "failed to write to trace file: {}", e);
         }
         if let Err(e) = writeln!(
             brz_log_file,
             "bug reports to https://bugs.launchpad.net/brz/+filebug"
         ) {
-            eprintln!("failed to write to trace file: {}", e);
+            warn!(target: "brz", "failed to write to trace file: {}", e);
         }
     }
 


### PR DESCRIPTION
Rust code in `open_brz_log` was writing failures via `eprintln!`, which bypasses Python's `sys.stderr` redirection and the test fixture's `BreezyTraceHandler`. Messages like "failed to open trace file" leaked into `brz selftest`'s real stderr instead of being captured in the test's `log` attachment.