### PR TITLE
git: Add transport object-store and ref-container tests

### DIFF
--- a/breezy/git/tests/test_transportgit.py
+++ b/breezy/git/tests/test_transportgit.py
@@ -63,7 +63,9 @@ class TransportObjectStoreTests(PackBasedObjectStoreTests, TestCaseWithTransport
         self.assertEqual(2, len(restore.packs))
 
 
-# FIXME: Unfortunately RefsContainerTests requires on a specific set of refs existing.
+# TODO: The dulwich RefsContainerTests base class used to provide a shared set
+# of symref tests, but it was dropped from dulwich. Reinstate the symref
+# coverage (e.g. by vendoring those tests) once an equivalent is available.
 
 
 class TransportRefContainerTests(TestCaseWithTransport):

--- a/breezy/git/transportgit.py
+++ b/breezy/git/transportgit.py
@@ -494,7 +494,7 @@ class TransportRefsContainer(RefsContainer):
             # This is racy, but what can we do?
             if transport.has(lockname):
                 raise LockContention(name) from err
-            transport.put_bytes(lockname, b"Locked by brz-git")
+            transport.put_bytes(lockname, b"Locked by Breezy")
             return LogicalLockResult(lambda: transport.delete(lockname))
         else:
             try:


### PR DESCRIPTION
Add tests for TransportObjectStore pack handling and TransportRefContainer packed-refs handling, and rename the git lock marker to "Locked by Breezy".

The dulwich RefsContainerTests base class that the original symref tests relied on has since been dropped from dulwich, so that part is left out for now (see the TODO in the test module).